### PR TITLE
.class file fix for SourceFile in plexus-compiler-eclipse

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -179,7 +179,6 @@ public class EclipseJavaCompiler
         // ----------------------------------------------------------------------
 
         settings.put( CompilerOptions.OPTION_LineNumberAttribute, CompilerOptions.GENERATE );
-
         settings.put( CompilerOptions.OPTION_SourceFileAttribute, CompilerOptions.GENERATE );
         
         // compiler-specific extra options override anything else in the config object...
@@ -341,7 +340,26 @@ public class EclipseJavaCompiler
 
         public char[] getFileName()
         {
-            return className.toCharArray();
+            //Aaron LaBella, fix on 12/17/2011
+            //
+            //according the Java .class spec, the file name
+            //should be the actual Foo.java name, not the className
+            //
+            //this bug was causing issues when maven dependencies
+            //were not available in the workspace and you tried
+            //to step into and/or debug the class files.  the result
+            //was a "source not found" error from Eclipse, even if
+            //the source lookup location/path was clearly present.
+            String fileName = sourceFile;
+
+            int lastSeparator = fileName.lastIndexOf(File.separatorChar);
+          
+            if (lastSeparator > 0)
+            {
+              fileName = fileName.substring(lastSeparator+1);
+            }
+
+            return fileName.toCharArray();
         }
 
         public char[] getContents()


### PR DESCRIPTION
Please pull this fix, the .class files generated by the plexus-complier-eclipse do _not_ adhere to the sun class file spec.  

http://java.sun.com/docs/books/jvms/second_edition/html/ClassFile.doc.html#79868

The use case here is, try to have an eclipse IDE lookup the source, or set a debugger breakpoint for a maven dependency that is _not_ in the workspace.  If that dependency was compiled by the plexus-compiler-eclipse plugin, then eclipse will never be able to correlate the .class file using the SourceFile attribute because it does not adhere to the spec.  You can easily compare the .class files generate by javac to those generate by this plugin and see that the SourceFile attributes do not match.

This bug addresses the following JIRA:

http://jira.codehaus.org/browse/MCOMPILER-142

Ideally, we could release 1.8.3 of the plexus-compiler-plugin as soon as possible because this fix is critical to our projects, and I've currently deployed it to a temporary plugin-repository within our internal central Maven repository instance.

Thank you for your time and consideration.

Aaron LaBella
Certified IT Specialist
IBM
