### PR TITLE
Some updates around the new CompilerResult logic.

### DIFF
--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/AbstractCompiler.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/AbstractCompiler.java
@@ -78,7 +78,7 @@ public abstract class AbstractCompiler
     public CompilerResult performCompile(CompilerConfiguration configuration)
             throws CompilerException 
     {
-        throw new CompilerNotImplementedException("The preformCompile method has not been implemented.");
+        throw new CompilerNotImplementedException("The performCompile method has not been implemented.");
     }
 
     @Deprecated

--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerMessage.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerMessage.java
@@ -53,8 +53,6 @@ public class CompilerMessage
 {
     /**
      * The kind of message.
-     *
-     * @since 2.0
      */
     private Kind kind;
 
@@ -92,6 +90,7 @@ public class CompilerMessage
     /**
      * Constructs a compiler message.
      *
+     * @deprecated        Use {@link #CompilerMessage(String,Kind,int,int,int,int,String)} instead
      * @param file        The name of the file containing the offending program text
      * @param error       <code>true</code> if this is a error message, or <code>false</code> if it
      *                    is a warning message
@@ -101,6 +100,7 @@ public class CompilerMessage
      * @param endcolumn   The end column number of the offending program text
      * @param message     The actual message text produced by the language processor
      */
+    @Deprecated
     public CompilerMessage( String file, boolean error, int startline, int startcolumn, int endline, int endcolumn,
                             String message )
     {
@@ -139,20 +139,25 @@ public class CompilerMessage
     /**
      * The warning message constructor.
      *
+     * @deprecated    Use {@link #CompilerMessage(String,Kind)} instead
      * @param message The actual message text produced by the language processor
      */
+    @Deprecated
     public CompilerMessage( String message )
     {
         this.message = message;
+        this.kind = Kind.WARNING;
     }
 
     /**
      * Constructs a compiler message.
      *
+     * @deprecated    Use {@link #CompilerMessage(String,Kind)} instead
      * @param message The actual message text produced by the language processor
      * @param error   <code>true</code> if this is a error message, or <code>false</code> if it
      *                is a warning message
      */
+    @Deprecated
     public CompilerMessage( String message, boolean error )
     {
         this.message = message;

--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerResult.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerResult.java
@@ -30,10 +30,7 @@ import java.util.List;
  */
 public class CompilerResult
 {
-    /**
-     * true per default
-     */
-    private boolean success = true;
+    private boolean success;
 
     private List<CompilerMessage> compilerMessages;
 
@@ -42,7 +39,7 @@ public class CompilerResult
      */
     public CompilerResult()
     {
-        // no op
+        this.success = true;
     }
 
     /**


### PR DESCRIPTION
- deprecated some constructors in CompilerMessage which doesn't use the new Kind enum
- plexus-compiler-javac should now fully use the CompilerResult object to encapsulate the compilation success result

Signed-off-by: Anders Hammar anders@hammar.net
