### PR TITLE
upgrade JDT version and add -properties parameter parsing

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -19,9 +19,9 @@
       <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jdt</groupId>
-      <artifactId>core</artifactId>
-      <version>3.3.0-v_771</version>
+      <groupId>org.eclipse.tycho</groupId>
+      <artifactId>org.eclipse.jdt.core</artifactId>
+      <version>3.8.1.v20120531-0637</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.core</groupId>

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -49,7 +49,9 @@ import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -59,10 +61,12 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
 
@@ -180,6 +184,11 @@ public class EclipseJavaCompiler
         if ( extras != null && !extras.isEmpty() )
         {
             settings.putAll( extras );
+        }
+
+        if(settings.containsKey("-properties")) {
+        	initializeWarnings(settings.get("-properties"), settings);
+        	settings.remove("-properties");
         }
 
         IProblemFactory problemFactory = new DefaultProblemFactory( Locale.getDefault() );
@@ -388,6 +397,11 @@ public class EclipseJavaCompiler
 
             return result;
         }
+
+		public boolean ignoreOptionalProblems() {
+			// TODO Auto-generated method stub
+			return false;
+		}
     }
 
     private class EclipseCompilerINameEnvironment
@@ -621,5 +635,35 @@ public class EclipseJavaCompiler
                 }
             }
         }
+    }
+    
+    private void initializeWarnings(String propertiesFile, Map<String, String> setting) {
+    	File file = new File(propertiesFile);
+    	if (!file.exists()) {
+    		throw new IllegalArgumentException("Properties file not exist"); 
+    	}
+    	BufferedInputStream stream = null;
+    	Properties properties = null;
+    	try {
+    		stream = new BufferedInputStream(new FileInputStream(propertiesFile));
+    		properties = new Properties();
+    		properties.load(stream);
+    	} catch(IOException e) {
+    		e.printStackTrace();
+    		throw new IllegalArgumentException("Properties file load error"); 
+    	} finally {
+    		if (stream != null) {
+    			try {
+    				stream.close();
+    			} catch(IOException e) {
+    				// ignore
+    			}
+    		}
+    	}
+    	for (Iterator iterator = properties.entrySet().iterator(); iterator.hasNext(); ) {
+    		Map.Entry entry = (Map.Entry) iterator.next();
+    		final String key = (String) entry.getKey();
+			setting.put(key, entry.getValue().toString());
+    	}
     }
 }


### PR DESCRIPTION
1. The jdt version using in maven-compiler-plugin is 3.3.0-v_771, it is the version several years ago, I upgrade the version in pom file.
2. JDT support using properties file to config the arguments, but current version doesn't support this function. I changed the source code to add this function. User can use below setting in their pom file.
   &lt;compilerArguments>
     &lt;properties>jdt-config.properties&lt;/properties>
   &lt;/compilerArguments>
