### PR TITLE
Print all warnings and errors messages with the absolute filename.

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -269,9 +269,9 @@ public class EclipseJavaCompiler
 
     }
 
-    private CompilerMessage handleWarning( IProblem warning )
+    private CompilerMessage handleWarning( String fileName, IProblem warning )
     {
-        return new CompilerMessage( new String( warning.getOriginatingFileName() ), CompilerMessage.Kind.WARNING,
+        return new CompilerMessage( fileName, CompilerMessage.Kind.WARNING,
                                     warning.getSourceLineNumber(), warning.getSourceStart(),
                                     warning.getSourceLineNumber(), warning.getSourceEnd(), warning.getMessage() );
     }
@@ -359,6 +359,11 @@ public class EclipseJavaCompiler
             }
 
             return fileName.toCharArray();
+        }
+
+        String getAbsolutePath()
+        {
+            return sourceFile;
         }
 
         public char[] getContents()
@@ -583,11 +588,11 @@ public class EclipseJavaCompiler
 
                 for ( IProblem problem : problems )
                 {
-                    String name = new String( problem.getOriginatingFileName() );
+                    String name = getFileName(result.getCompilationUnit(), problem.getOriginatingFileName());
 
                     if ( problem.isWarning() )
                     {
-                        errors.add( handleWarning( problem ) );
+                        errors.add( handleWarning( name, problem ) );
                     }
                     else
                     {
@@ -644,6 +649,17 @@ public class EclipseJavaCompiler
                         IOUtil.close( fout );
                     }
                 }
+            }
+        }
+
+        private String getFileName( ICompilationUnit compilationUnit, char[] originalFileName ) {
+            if ( compilationUnit instanceof CompilationUnit )
+            {
+                return ((CompilationUnit)compilationUnit).getAbsolutePath();
+            }
+            else
+            {
+                return String.valueOf(originalFileName);
             }
         }
     }


### PR DESCRIPTION
Currently the eclipse compiler shows warnings and error messages using the base file name only. This leads to ambiguous warnings, e.g. if there are multiple files with the same name. In order to provide a correct mapping to the original compilation unit in my Jenkins warnings plug-in it would be quite helpful if all warnings and error rather would use the absolute path.
