### PR TITLE
fix support for showWarnings option in eclipse compiler

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -133,9 +133,12 @@ public class EclipseJavaCompiler
 
         if ( !config.isShowWarnings() )
         {
-            // TODO: Implement. I'm not sure what value to pass - trygve
-//            settings.put( CompilerOptions.OPTION_SuppressWarnings,  );
-            settings.put( CompilerOptions.OPTION_SuppressWarnings, CompilerOptions.ENABLED );
+            Map opts = new CompilerOptions().getMap();
+            for (Object optKey : opts.keySet()) {
+                if (opts.get(optKey).equals(CompilerOptions.WARNING)) {
+                    settings.put((String) optKey, CompilerOptions.IGNORE);
+                }
+            }
         }
 
         String sourceVersion = decodeVersion( config.getSourceVersion() );


### PR DESCRIPTION
Previous implementation of turning off warnings was trying to achieve this
by enabling OPTION_SuppressWarnings, but it was wrong. Enabling this
option tell eclipse to honor @SuppressWarning annotations only, and does
not turn off all other warnings.

To do this we have to iterate thru all the options, and change those that
were set as WARNING to IGNORE. This is how the do it for example in
eclipse batch compiler.
