### PR TITLE
Make target version actually take effect.

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -154,11 +154,7 @@ public class EclipseJavaCompiler
         if ( targetVersion != null )
         {
             settings.put( CompilerOptions.OPTION_TargetPlatform, targetVersion );
-
-            if ( config.isOptimize() )
-            {
-                settings.put( CompilerOptions.OPTION_Compliance, targetVersion );
-            }
+            settings.put( CompilerOptions.OPTION_Compliance, targetVersion );
         }
 
         if ( StringUtils.isNotEmpty( config.getSourceEncoding() ) )


### PR DESCRIPTION
The optimize option has no bearing and is incorrectly used on ECJ.