### PR TITLE
Import package uppercase

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,3 @@
-The cannonical git repository is located at https://github.com/codehaus-plexus/plexus-compiler
+The canonical git repository is located at https://github.com/codehaus-plexus/plexus-compiler
 
 

--- a/plexus-compiler-api/pom.xml
+++ b/plexus-compiler-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.5</version>
+    <version>2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-api</artifactId>

--- a/plexus-compiler-api/pom.xml
+++ b/plexus-compiler-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.7-SNAPSHOT</version>
+    <version>2.7</version>
   </parent>
 
   <artifactId>plexus-compiler-api</artifactId>

--- a/plexus-compiler-api/pom.xml
+++ b/plexus-compiler-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.6</version>
+    <version>2.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-api</artifactId>

--- a/plexus-compiler-api/pom.xml
+++ b/plexus-compiler-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5</version>
   </parent>
 
   <artifactId>plexus-compiler-api</artifactId>

--- a/plexus-compiler-api/pom.xml
+++ b/plexus-compiler-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.7</version>
+    <version>2.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-api</artifactId>

--- a/plexus-compiler-api/pom.xml
+++ b/plexus-compiler-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>plexus-compiler-api</artifactId>

--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.codehaus.plexus.compiler.CompilerConfiguration.CompilerReuseStrategy;
+
 /**
  * @author jdcasey
  */
@@ -117,6 +119,12 @@ public class CompilerConfiguration
      * -processor parameters in jdk 1.6+
      */
     private String[] annotationProcessors;
+
+    /**
+     * -processorpath parameter in jdk 1.6+. If specified, annotation processors are only searched in the processor
+     * path. Otherwise they are searched in the classpath.
+     */
+    private List<String> processorPathEntries;
 
     /**
      * default value {@link CompilerReuseStrategy.ReuseCreated}
@@ -341,6 +349,7 @@ public class CompilerConfiguration
      * @deprecated will be removed in 2.X use #getCustomCompilerArgumentsAsMap
      * @return
      */
+    @Deprecated
     public LinkedHashMap<String, String> getCustomCompilerArguments()
     {
         return new LinkedHashMap<String, String>( customCompilerArguments );
@@ -350,6 +359,7 @@ public class CompilerConfiguration
      * @deprecated will be removed in 2.X use #setCustomCompilerArgumentsAsMap
      * @param customCompilerArguments
      */
+    @Deprecated
     public void setCustomCompilerArguments( LinkedHashMap<String, String> customCompilerArguments )
     {
         if ( customCompilerArguments == null )
@@ -360,8 +370,8 @@ public class CompilerConfiguration
         {
             this.customCompilerArguments = customCompilerArguments;
         }
-    }    
-    
+    }
+
     public Map<String, String> getCustomCompilerArgumentsAsMap()
     {
         return new LinkedHashMap<String, String>( customCompilerArguments );
@@ -507,6 +517,40 @@ public class CompilerConfiguration
     public String[] getAnnotationProcessors()
     {
         return annotationProcessors;
+    }
+
+    /**
+     * -processorpath parameter in jdk 1.6+. If specified, annotation processors are only searched in the processor
+     * path. Otherwise they are searched in the classpath.
+     *
+     * @param entry processor path entry to add
+     */
+    public void addProcessorPathEntry(String entry) {
+        if ( processorPathEntries == null ) {
+            processorPathEntries = new LinkedList<String>();
+        }
+
+        processorPathEntries.add( entry );
+    }
+
+    /**
+     * -processorpath parameter in jdk 1.6+. If specified, annotation processors are only searched in the processor
+     * path. Otherwise they are searched in the classpath.
+     *
+     * @return the processorPathEntries
+     */
+    public List<String> getProcessorPathEntries() {
+        return processorPathEntries;
+    }
+
+    /**
+     * -processorpath parameter in jdk 1.6+. If specified, annotation processors are only searched in the processor
+     * path. Otherwise they are searched in the classpath.
+     *
+     * @param processorPathEntries the processorPathEntries to set
+     */
+    public void setProcessorPathEntries(List<String> processorPathEntries) {
+        this.processorPathEntries = processorPathEntries;
     }
 
     public CompilerReuseStrategy getCompilerReuseStrategy()

--- a/plexus-compiler-manager/pom.xml
+++ b/plexus-compiler-manager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.7</version>
+    <version>2.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-manager</artifactId>

--- a/plexus-compiler-manager/pom.xml
+++ b/plexus-compiler-manager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>plexus-compiler-manager</artifactId>

--- a/plexus-compiler-manager/pom.xml
+++ b/plexus-compiler-manager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.7-SNAPSHOT</version>
+    <version>2.7</version>
   </parent>
 
   <artifactId>plexus-compiler-manager</artifactId>

--- a/plexus-compiler-manager/pom.xml
+++ b/plexus-compiler-manager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.5</version>
+    <version>2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-manager</artifactId>

--- a/plexus-compiler-manager/pom.xml
+++ b/plexus-compiler-manager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5</version>
   </parent>
 
   <artifactId>plexus-compiler-manager</artifactId>

--- a/plexus-compiler-manager/pom.xml
+++ b/plexus-compiler-manager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.6</version>
+    <version>2.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-manager</artifactId>

--- a/plexus-compiler-test/pom.xml
+++ b/plexus-compiler-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5</version>
   </parent>
 
   <artifactId>plexus-compiler-test</artifactId>

--- a/plexus-compiler-test/pom.xml
+++ b/plexus-compiler-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.5</version>
+    <version>2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-test</artifactId>

--- a/plexus-compiler-test/pom.xml
+++ b/plexus-compiler-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>plexus-compiler-test</artifactId>

--- a/plexus-compiler-test/pom.xml
+++ b/plexus-compiler-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.7</version>
+    <version>2.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-test</artifactId>

--- a/plexus-compiler-test/pom.xml
+++ b/plexus-compiler-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.6</version>
+    <version>2.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-test</artifactId>

--- a/plexus-compiler-test/pom.xml
+++ b/plexus-compiler-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.7-SNAPSHOT</version>
+    <version>2.7</version>
   </parent>
 
   <artifactId>plexus-compiler-test</artifactId>

--- a/plexus-compilers/plexus-compiler-aspectj/pom.xml
+++ b/plexus-compilers/plexus-compiler-aspectj/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6</version>
+    <version>2.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-aspectj</artifactId>

--- a/plexus-compilers/plexus-compiler-aspectj/pom.xml
+++ b/plexus-compilers/plexus-compiler-aspectj/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>plexus-compiler-aspectj</artifactId>

--- a/plexus-compilers/plexus-compiler-aspectj/pom.xml
+++ b/plexus-compilers/plexus-compiler-aspectj/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7-SNAPSHOT</version>
+    <version>2.7</version>
   </parent>
 
   <artifactId>plexus-compiler-aspectj</artifactId>

--- a/plexus-compilers/plexus-compiler-aspectj/pom.xml
+++ b/plexus-compilers/plexus-compiler-aspectj/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7</version>
+    <version>2.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-aspectj</artifactId>

--- a/plexus-compilers/plexus-compiler-aspectj/pom.xml
+++ b/plexus-compilers/plexus-compiler-aspectj/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5</version>
   </parent>
 
   <artifactId>plexus-compiler-aspectj</artifactId>

--- a/plexus-compilers/plexus-compiler-aspectj/pom.xml
+++ b/plexus-compilers/plexus-compiler-aspectj/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.5</version>
+    <version>2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-aspectj</artifactId>

--- a/plexus-compilers/plexus-compiler-csharp/pom.xml
+++ b/plexus-compilers/plexus-compiler-csharp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.5</version>
+    <version>2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-csharp</artifactId>

--- a/plexus-compilers/plexus-compiler-csharp/pom.xml
+++ b/plexus-compilers/plexus-compiler-csharp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6</version>
+    <version>2.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-csharp</artifactId>

--- a/plexus-compilers/plexus-compiler-csharp/pom.xml
+++ b/plexus-compilers/plexus-compiler-csharp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>plexus-compiler-csharp</artifactId>

--- a/plexus-compilers/plexus-compiler-csharp/pom.xml
+++ b/plexus-compilers/plexus-compiler-csharp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7-SNAPSHOT</version>
+    <version>2.7</version>
   </parent>
 
   <artifactId>plexus-compiler-csharp</artifactId>

--- a/plexus-compilers/plexus-compiler-csharp/pom.xml
+++ b/plexus-compilers/plexus-compiler-csharp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7</version>
+    <version>2.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-csharp</artifactId>

--- a/plexus-compilers/plexus-compiler-csharp/pom.xml
+++ b/plexus-compilers/plexus-compiler-csharp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5</version>
   </parent>
 
   <artifactId>plexus-compiler-csharp</artifactId>

--- a/plexus-compilers/plexus-compiler-csharp/src/main/java/org/codehaus/plexus/compiler/csharp/CSharpCompiler.java
+++ b/plexus-compilers/plexus-compiler-csharp/src/main/java/org/codehaus/plexus/compiler/csharp/CSharpCompiler.java
@@ -547,6 +547,14 @@ Options can be of the form -option or /option
         {
             for ( String sourceLocation : config.getSourceLocations() )
             {
+                if (!new File(sourceLocation).exists())
+                {
+                    if ( config.isDebug() )
+                    {
+                        System.out.println( "Ignoring not found sourceLocation at: " + sourceLocation );
+                    }
+                    continue;
+                }
                 sources.addAll( getSourceFilesForSourceRoot( config, sourceLocation ) );
             }
         }

--- a/plexus-compilers/plexus-compiler-csharp/src/main/java/org/codehaus/plexus/compiler/csharp/JarUtil.java
+++ b/plexus-compilers/plexus-compiler-csharp/src/main/java/org/codehaus/plexus/compiler/csharp/JarUtil.java
@@ -1,0 +1,40 @@
+package org.codehaus.plexus.compiler.csharp;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+public class JarUtil {
+    public static void extract( File destDir, File jarFile ) throws IOException
+    {
+        JarFile jar = new JarFile( jarFile );
+        Enumeration enumEntries = jar.entries();
+        while ( enumEntries.hasMoreElements() ) {
+            JarEntry file = ( JarEntry ) enumEntries.nextElement();
+            File f = new File( destDir + File.separator + file.getName() );
+            if ( file.isDirectory() )
+            {
+                f.mkdir();
+                continue;
+            }
+            InputStream is = jar.getInputStream( file );
+            FileOutputStream fos = new FileOutputStream( f );
+            try
+            {
+                while ( is.available() > 0 )
+                {
+                    fos.write( is.read() );
+                }
+            }
+            finally
+            {
+                is.close();
+                fos.close();
+            }
+        }
+    }
+}

--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6</version>
+    <version>2.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-eclipse</artifactId>

--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7</version>
+    <version>2.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-eclipse</artifactId>

--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7-SNAPSHOT</version>
+    <version>2.7</version>
   </parent>
 
   <artifactId>plexus-compiler-eclipse</artifactId>

--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.5</version>
+    <version>2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-eclipse</artifactId>

--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -21,25 +21,7 @@
     <dependency>
       <groupId>org.eclipse.tycho</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.10.0.v20140604-1726</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.core</groupId>
-          <artifactId>resources</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.core</groupId>
-          <artifactId>runtime</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.core</groupId>
-          <artifactId>filesystem</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse</groupId>
-          <artifactId>text</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>3.11.1.v20150902-1521</version>
     </dependency>
   </dependencies>
 </project>

--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5</version>
   </parent>
 
   <artifactId>plexus-compiler-eclipse</artifactId>

--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>plexus-compiler-eclipse</artifactId>

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -183,10 +183,10 @@ public class EclipseJavaCompiler
 
         settings.putAll( extras );
 
-        if ( settings.containsKey( "-properties" ) )
+        if ( settings.containsKey( "properties" ) )
         {
-            initializeWarnings( settings.get( "-properties" ), settings );
-            settings.remove( "-properties" );
+            initializeWarnings( settings.get( "properties" ), settings );
+            settings.remove( "properties" );
         }
 
         IProblemFactory problemFactory = new DefaultProblemFactory( Locale.getDefault() );

--- a/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/BAR/Baz.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/BAR/Baz.java
@@ -1,0 +1,4 @@
+package org.codehaus.BAR;
+
+public class Baz {
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/bar/Baz.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/bar/Baz.java
@@ -1,4 +1,0 @@
-package org.codehaus.bar;
-
-public class Baz {
-}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/bar/Baz.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/bar/Baz.java
@@ -1,0 +1,4 @@
+package org.codehaus.bar;
+
+public class Baz {
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Import.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Import.java
@@ -1,6 +1,6 @@
 package org.codehaus.foo;
 
-import org.codehaus.bar.Baz;
+import org.codehaus.BAR.Baz;
 
 public class Import
 {

--- a/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Import.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Import.java
@@ -1,0 +1,8 @@
+package org.codehaus.foo;
+
+import org.codehaus.bar.Baz;
+
+public class Import
+{
+    public Baz baz;
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
@@ -101,6 +101,26 @@ public class EclipseCompilerTest
 
     }
 
+    public void testInitializeWarningsForPropertiesArgument()
+        throws Exception
+    {
+        org.codehaus.plexus.compiler.Compiler compiler = (Compiler) lookup( Compiler.ROLE, getRoleHint() );
+
+        CompilerConfiguration compilerConfig = createMinimalCompilerConfig();
+
+        compilerConfig.addCompilerCustomArgument( "-properties", "file_does_not_exist" );
+
+        try
+        {
+            compiler.performCompile( compilerConfig );
+            fail( "looking up the properties file should have thrown an exception" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            assertEquals( "Properties file not exist", e.getMessage() );
+        }
+    }
+
     private CompilerConfiguration createMinimalCompilerConfig()
     {
         CompilerConfiguration compilerConfig = new CompilerConfiguration();

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
@@ -66,7 +66,8 @@ public class EclipseCompilerTest
     protected Collection<String> expectedOutputFiles()
     {
         return Arrays.asList( new String[] { "org/codehaus/foo/Deprecation.class", "org/codehaus/foo/ExternalDeps.class",
-            "org/codehaus/foo/Person.class", "org/codehaus/foo/ReservedWord.class" } );
+                                             "org/codehaus/foo/Person.class", "org/codehaus/foo/ReservedWord.class",
+                                             "org/codehaus/foo/Import.class", "org/codehaus/bar/Baz.class" } );
     }
 
     // The test is fairly meaningless as we can not validate anything

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
@@ -67,7 +67,7 @@ public class EclipseCompilerTest
     {
         return Arrays.asList( new String[] { "org/codehaus/foo/Deprecation.class", "org/codehaus/foo/ExternalDeps.class",
                                              "org/codehaus/foo/Person.class", "org/codehaus/foo/ReservedWord.class",
-                                             "org/codehaus/foo/Import.class", "org/codehaus/bar/Baz.class" } );
+                                             "org/codehaus/foo/Import.class", "org/codehaus/BAR/Baz.class" } );
     }
 
     // The test is fairly meaningless as we can not validate anything

--- a/plexus-compilers/plexus-compiler-j2objc/README.md
+++ b/plexus-compilers/plexus-compiler-j2objc/README.md
@@ -1,0 +1,32 @@
+J2ObjC Plexus compiler
+===================
+
+ The J2ObjC Plexus compiler is a tool to compile java source files to objective-c by calling the j2objc tool.
+ 
+ 	```
+	   <build>
+	    <plugins>
+	      <plugin>
+	        <artifactId>maven-compiler-plugin</artifactId>
+	        <version>3.3</version>
+	        <configuration>
+	          <fork>true</fork>
+	          
+		<compilerId>j2objc</compilerId>  
+		        <executable>${J2OBJC_DISTRIBUTION}/j2objc</executable>
+          <compilerArguments>
+			<use-arc/>
+            <x>objective-c++</x>
+          </compilerArguments>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-j2objc</artifactId>
+            <version>2.6-SNAPSHOT</version>
+          </dependency>          
+        </dependencies>
+      </plugin>    
+ 
+ 	```
+  

--- a/plexus-compilers/plexus-compiler-j2objc/README.md
+++ b/plexus-compilers/plexus-compiler-j2objc/README.md
@@ -10,23 +10,23 @@ J2ObjC Plexus compiler
 	        <artifactId>maven-compiler-plugin</artifactId>
 	        <version>3.3</version>
 	        <configuration>
-	          <fork>true</fork>
-	          
-		<compilerId>j2objc</compilerId>  
-		        <executable>${J2OBJC_DISTRIBUTION}/j2objc</executable>
-          <compilerArguments>
-			<use-arc/>
-            <x>objective-c++</x>
-          </compilerArguments>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-j2objc</artifactId>
-            <version>2.6-SNAPSHOT</version>
-          </dependency>          
-        </dependencies>
-      </plugin>    
- 
+	          <fork>true</fork>	          
+   		      <compilerId>j2objc</compilerId>  
+		      <executable>${J2OBJC_DISTRIBUTION}/j2objc</executable>
+              <compilerArguments>
+			    <use-arc/>
+                <x>objective-c</x>
+                <sourcepath>src/main/java</sourcepath>
+              </compilerArguments>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-compiler-j2objc</artifactId>
+                <version>2.6-SNAPSHOT</version>
+              </dependency>          
+            </dependencies>
+          </plugin>
+          ...
  	```
   

--- a/plexus-compilers/plexus-compiler-j2objc/pom.xml
+++ b/plexus-compilers/plexus-compiler-j2objc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>plexus-compiler-j2objc</artifactId>

--- a/plexus-compilers/plexus-compiler-j2objc/pom.xml
+++ b/plexus-compilers/plexus-compiler-j2objc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7-SNAPSHOT</version>
+    <version>2.7</version>
   </parent>
 
   <artifactId>plexus-compiler-j2objc</artifactId>

--- a/plexus-compilers/plexus-compiler-j2objc/pom.xml
+++ b/plexus-compilers/plexus-compiler-j2objc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7</version>
+    <version>2.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-j2objc</artifactId>

--- a/plexus-compilers/plexus-compiler-j2objc/pom.xml
+++ b/plexus-compilers/plexus-compiler-j2objc/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.plexus</groupId>
+    <artifactId>plexus-compilers</artifactId>
+    <version>2.6-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>plexus-compiler-j2objc</artifactId>
+
+  <name>Plexus J2ObjC Compiler</name>
+  <description>J2ObjC Compiler support for Plexus Compiler component.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/plexus-compilers/plexus-compiler-j2objc/pom.xml
+++ b/plexus-compilers/plexus-compiler-j2objc/pom.xml
@@ -19,4 +19,26 @@
       <artifactId>plexus-utils</artifactId>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>no-tests-if-not-on-osx</id>
+      <activation>
+        <os>
+          <family>!mac</family>
+        </os>	
+      </activation>
+      <build>
+	<plugins>
+	  <plugin>
+	    <groupId>org.apache.maven.plugins</groupId>
+	    <artifactId>maven-surefire-plugin</artifactId>
+	    <configuration>
+	      <skipTests>true</skipTests>
+	    </configuration>
+	  </plugin>
+	</plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/plexus-compilers/plexus-compiler-j2objc/pom.xml
+++ b/plexus-compilers/plexus-compiler-j2objc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6</version>
+    <version>2.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-j2objc</artifactId>

--- a/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/DefaultJ2ObjCCompilerParser.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/DefaultJ2ObjCCompilerParser.java
@@ -5,31 +5,29 @@ import org.codehaus.plexus.compiler.CompilerMessage.Kind;
 import org.codehaus.plexus.util.StringUtils;
 
 /**
- * Handles output from both mono with only the line number
- * <p/>
- * ex error = "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./TestRunnerThread.cs(29) error CS0246: Cannot find type 'NameValueCollection'"
- * <p/>
- * and errors from mono & csc on windows which has column num also
- * <p/>
- * ex error = "src\\test\\csharp\\Hierarchy\\Logger.cs(98,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'";
- *
- * @author <a href="mailto:gdodinet@karmicsoft.com">Gilles Dodinet</a>
- * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
- * @author <a href="mailto:matthew.pocock@ncl.ac.uk">Matthew Pocock</a>
- * @author <a href="mailto:chris.stevenson@gmail.com">Chris Stevenson</a>
+ * Handle the output of J2ObjC
+ * @author lmaitre
  */
 public class DefaultJ2ObjCCompilerParser
 {
 
     private static String ERROR_PREFIX = "error ";
 
-    private static String COMPILATION_PREFIX = "Compilation ";
+    private static String CONVERT_PREFIX = "translating ";
+    
+    private static String TRANSLATION_PREFIX = "Translated ";
 
     private static String MAGIC_LINE_MARKER = ".cs(";
 
     private static String MAGIC_LINE_MARKER_2 = ")";
 
-
+/**
+Unknown output: translating /Users/lmaitre/Workspaces/IOSSamples/maven-quickstart-j2objc/src/main/java/de/test/App.java
+Unknown output: Translated 1 file: 0 errors, 0 warnings
+Unknown output: Translated 2 methods as functions
+ * @param line
+ * @return
+ */
     public static CompilerMessage parseLine( String line )
     {
         CompilerMessage ce = null;
@@ -80,11 +78,12 @@ public class DefaultJ2ObjCCompilerParser
         {
             message = line.substring( ERROR_PREFIX.length() );
         }
-        else if ( line.startsWith( COMPILATION_PREFIX ) )
+        else if ( line.startsWith( CONVERT_PREFIX ) )
         {
-            // ignore
-
-            return null;
+        	message = line;
+        } else if ( line.startsWith( TRANSLATION_PREFIX ) )
+        {
+        	message = line;
         }
         else if ( line.indexOf( MAGIC_LINE_MARKER ) != -1 )
         {
@@ -129,11 +128,11 @@ public class DefaultJ2ObjCCompilerParser
         if ( line.startsWith( ERROR_PREFIX ) )
         {
             message = line.substring( ERROR_PREFIX.length() );
-        }
+        }/*
         else if ( line.startsWith( COMPILATION_PREFIX ) )
         {
             return null;
-        }
+        }*/
         else if ( line.indexOf( MAGIC_LINE_MARKER ) != -1 )
         {
             int i = line.indexOf( MAGIC_LINE_MARKER );

--- a/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/DefaultJ2ObjCCompilerParser.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/DefaultJ2ObjCCompilerParser.java
@@ -5,55 +5,49 @@ import org.codehaus.plexus.compiler.CompilerMessage.Kind;
 
 /**
  * Handle the output of J2ObjC
+ * 
  * @author lmaitre
  */
-public class DefaultJ2ObjCCompilerParser
-{
+public class DefaultJ2ObjCCompilerParser {
 
-    private static String ERROR_PREFIX = "error: ";
+	private static String ERROR_PREFIX = "error: ";
 
-    private static String CONVERT_PREFIX = "translating ";
-    
-    private static String TRANSLATION_PREFIX = "Translated ";
+	private static String CONVERT_PREFIX = "translating ";
 
-/**
-Unknown output: translating /Users/lmaitre/Workspaces/IOSSamples/maven-quickstart-j2objc/src/main/java/de/test/App.java
-Unknown output: Translated 1 file: 0 errors, 0 warnings
-Unknown output: Translated 2 methods as functions
- * @param line
- * @return
- */
-    public static CompilerMessage parseLine( String line )
-    {
-        String file = null;
-        boolean error = false;
-        int startline = -1;
-        int startcolumn = -1;
-        int endline = -1;
-        int endcolumn = -1;
-        String message;
+	private static String TRANSLATION_PREFIX = "Translated ";
 
-        if ( line.startsWith( ERROR_PREFIX ) )
-        {
-            message = line.substring( ERROR_PREFIX.length() );
-            error = true;
-        }
-        else if ( line.startsWith( CONVERT_PREFIX ) )
-        {
-        	message = line;
-        } else if ( line.startsWith( TRANSLATION_PREFIX ) )
-        {
-        	message = line;
-        }
-        else
-        {
-            System.err.println( "Unknown output: " + line );
+	/**
+	 * Parse a line of log, reading the error and translating lines.
+	 * 
+	 * @param line
+	 * @return The compiler message for this line or null if there is no need of
+	 *         a message.
+	 */
+	public static CompilerMessage parseLine(String line) {
+		String file = null;
+		boolean error = false;
+		int startline = -1;
+		int startcolumn = -1;
+		int endline = -1;
+		int endcolumn = -1;
+		String message;
 
-            return null;
-        }
+		if (line.startsWith(ERROR_PREFIX)) {
+			message = line.substring(ERROR_PREFIX.length());
+			error = true;
+		} else if (line.startsWith(CONVERT_PREFIX)) {
+			message = line;
+		} else if (line.startsWith(TRANSLATION_PREFIX)) {
+			message = line;
+		} else {
+			System.err.println("Unknown output: " + line);
 
-        return new CompilerMessage( file, error ? Kind.ERROR : Kind.NOTE, startline, startcolumn, endline, endcolumn, message );
+			return null;
+		}
 
-    }
+		return new CompilerMessage(file, error ? Kind.ERROR : Kind.NOTE,
+				startline, startcolumn, endline, endcolumn, message);
+
+	}
 
 }

--- a/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/DefaultJ2ObjCCompilerParser.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/DefaultJ2ObjCCompilerParser.java
@@ -1,0 +1,188 @@
+package org.codehaus.plexus.compiler.j2objc;
+
+import org.codehaus.plexus.compiler.CompilerMessage;
+import org.codehaus.plexus.compiler.CompilerMessage.Kind;
+import org.codehaus.plexus.util.StringUtils;
+
+/**
+ * Handles output from both mono with only the line number
+ * <p/>
+ * ex error = "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./TestRunnerThread.cs(29) error CS0246: Cannot find type 'NameValueCollection'"
+ * <p/>
+ * and errors from mono & csc on windows which has column num also
+ * <p/>
+ * ex error = "src\\test\\csharp\\Hierarchy\\Logger.cs(98,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'";
+ *
+ * @author <a href="mailto:gdodinet@karmicsoft.com">Gilles Dodinet</a>
+ * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
+ * @author <a href="mailto:matthew.pocock@ncl.ac.uk">Matthew Pocock</a>
+ * @author <a href="mailto:chris.stevenson@gmail.com">Chris Stevenson</a>
+ */
+public class DefaultJ2ObjCCompilerParser
+{
+
+    private static String ERROR_PREFIX = "error ";
+
+    private static String COMPILATION_PREFIX = "Compilation ";
+
+    private static String MAGIC_LINE_MARKER = ".cs(";
+
+    private static String MAGIC_LINE_MARKER_2 = ")";
+
+
+    public static CompilerMessage parseLine( String line )
+    {
+        CompilerMessage ce = null;
+
+        if ( isOutputWithNoColumnNumber( line ) )
+        {
+            ce = parseLineWithNoColumnNumber( line );
+        }
+        else
+        {
+            ce = parseLineWithColumnNumberAndLineNumber( line );
+        }
+
+        return ce;
+    }
+
+    private static boolean isOutputWithNoColumnNumber( String line )
+    {
+
+        int i = line.indexOf( MAGIC_LINE_MARKER );
+
+        if ( i == -1 )
+        {
+            return true;
+        }
+
+        String chunk1 = line.substring( i + MAGIC_LINE_MARKER.length() );
+
+        int j = chunk1.indexOf( MAGIC_LINE_MARKER_2 );
+
+        String chunk2 = chunk1.substring( 0, j );
+
+        return ( chunk2.indexOf( "," ) == -1 );
+    }
+
+    private static CompilerMessage parseLineWithNoColumnNumber( String line )
+    {
+
+        String file = null;
+        boolean error = true;
+        int startline = -1;
+        int startcolumn = -1;
+        int endline = -1;
+        int endcolumn = -1;
+        String message;
+
+        if ( line.startsWith( ERROR_PREFIX ) )
+        {
+            message = line.substring( ERROR_PREFIX.length() );
+        }
+        else if ( line.startsWith( COMPILATION_PREFIX ) )
+        {
+            // ignore
+
+            return null;
+        }
+        else if ( line.indexOf( MAGIC_LINE_MARKER ) != -1 )
+        {
+            int i = line.indexOf( MAGIC_LINE_MARKER );
+
+            int j = line.indexOf( ' ', i );
+
+            file = line.substring( 0, i + 3 );
+
+            String num = line.substring( i + MAGIC_LINE_MARKER.length(), j - 1 );
+
+            startline = Integer.parseInt( num );
+
+            endline = startline;
+
+            message = line.substring( j + 1 + ERROR_PREFIX.length() );
+
+            error = line.indexOf( ") error" ) != -1;
+        }
+        else
+        {
+            System.err.println( "Unknown output: " + line );
+
+            return null;
+        }
+
+        return new CompilerMessage( file, error ? Kind.ERROR : Kind.NOTE, startline, startcolumn, endline, endcolumn, message );
+
+    }
+
+    private static CompilerMessage parseLineWithColumnNumberAndLineNumber( String line )
+    {
+
+        String file = null;
+        boolean error = true;
+        int startline = -1;
+        int startcolumn = -1;
+        int endline = -1;
+        int endcolumn = -1;
+        String message;
+
+        if ( line.startsWith( ERROR_PREFIX ) )
+        {
+            message = line.substring( ERROR_PREFIX.length() );
+        }
+        else if ( line.startsWith( COMPILATION_PREFIX ) )
+        {
+            return null;
+        }
+        else if ( line.indexOf( MAGIC_LINE_MARKER ) != -1 )
+        {
+            int i = line.indexOf( MAGIC_LINE_MARKER );
+
+            int j = line.indexOf( ' ', i );
+
+            file = line.substring( 0, i + 3 );
+
+            String linecol = line.substring( i + MAGIC_LINE_MARKER.length(), j - 2 );
+
+            String linenum = null;
+            String colnum = null;
+
+            if ( linecol.indexOf( "," ) > -1 && linecol.split( "," ).length == 2 )
+            {
+                linenum = linecol.split( "," )[0];
+                colnum = linecol.split( "," )[1];
+            }
+            else if ( linecol.split( "," ).length == 1 )
+            {
+                linenum = linecol.split( "," )[0];
+                colnum = "-1";
+            }
+            else
+            {
+                linenum = linecol.trim();
+                colnum = "-1";
+            }
+
+            startline = StringUtils.isEmpty( linenum ) ? -1 : Integer.parseInt( linenum );
+
+            startcolumn = StringUtils.isEmpty( colnum ) ? -1 : Integer.parseInt( colnum );
+
+            endline = startline;
+
+            endcolumn = startcolumn;
+
+            message = line.substring( j + 1 + ERROR_PREFIX.length() );
+
+            error = line.indexOf( "): error" ) != -1;
+        }
+        else
+        {
+            System.err.println( "Unknown output: " + line );
+
+            return null;
+        }
+
+        return new CompilerMessage( file, error ? Kind.ERROR : Kind.NOTE, startline, startcolumn, endline, endcolumn, message );
+    }
+
+}

--- a/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/DefaultJ2ObjCCompilerParser.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/DefaultJ2ObjCCompilerParser.java
@@ -2,7 +2,6 @@ package org.codehaus.plexus.compiler.j2objc;
 
 import org.codehaus.plexus.compiler.CompilerMessage;
 import org.codehaus.plexus.compiler.CompilerMessage.Kind;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Handle the output of J2ObjC
@@ -17,10 +16,6 @@ public class DefaultJ2ObjCCompilerParser
     
     private static String TRANSLATION_PREFIX = "Translated ";
 
-    private static String MAGIC_LINE_MARKER = ".cs(";
-
-    private static String MAGIC_LINE_MARKER_2 = ")";
-
 /**
 Unknown output: translating /Users/lmaitre/Workspaces/IOSSamples/maven-quickstart-j2objc/src/main/java/de/test/App.java
 Unknown output: Translated 1 file: 0 errors, 0 warnings
@@ -30,42 +25,6 @@ Unknown output: Translated 2 methods as functions
  */
     public static CompilerMessage parseLine( String line )
     {
-        CompilerMessage ce = null;
-
-        if ( isOutputWithNoColumnNumber( line ) )
-        {
-            ce = parseLineWithNoColumnNumber( line );
-        }
-        else
-        {
-            ce = parseLineWithColumnNumberAndLineNumber( line );
-        }
-
-        return ce;
-    }
-
-    private static boolean isOutputWithNoColumnNumber( String line )
-    {
-
-        int i = line.indexOf( MAGIC_LINE_MARKER );
-
-        if ( i == -1 )
-        {
-            return true;
-        }
-
-        String chunk1 = line.substring( i + MAGIC_LINE_MARKER.length() );
-
-        int j = chunk1.indexOf( MAGIC_LINE_MARKER_2 );
-
-        String chunk2 = chunk1.substring( 0, j );
-
-        return ( chunk2.indexOf( "," ) == -1 );
-    }
-
-    private static CompilerMessage parseLineWithNoColumnNumber( String line )
-    {
-
         String file = null;
         boolean error = false;
         int startline = -1;
@@ -86,24 +45,6 @@ Unknown output: Translated 2 methods as functions
         {
         	message = line;
         }
-        else if ( line.indexOf( MAGIC_LINE_MARKER ) != -1 )
-        {
-            int i = line.indexOf( MAGIC_LINE_MARKER );
-
-            int j = line.indexOf( ' ', i );
-
-            file = line.substring( 0, i + 3 );
-
-            String num = line.substring( i + MAGIC_LINE_MARKER.length(), j - 1 );
-
-            startline = Integer.parseInt( num );
-
-            endline = startline;
-
-            message = line.substring( j + 1 + ERROR_PREFIX.length() );
-
-            error = line.indexOf( ") error" ) != -1;
-        }
         else
         {
             System.err.println( "Unknown output: " + line );
@@ -113,76 +54,6 @@ Unknown output: Translated 2 methods as functions
 
         return new CompilerMessage( file, error ? Kind.ERROR : Kind.NOTE, startline, startcolumn, endline, endcolumn, message );
 
-    }
-
-    private static CompilerMessage parseLineWithColumnNumberAndLineNumber( String line )
-    {
-
-        String file = null;
-        boolean error = true;
-        int startline = -1;
-        int startcolumn = -1;
-        int endline = -1;
-        int endcolumn = -1;
-        String message;
-
-        if ( line.startsWith( ERROR_PREFIX ) )
-        {
-            message = line.substring( ERROR_PREFIX.length() );
-        }/*
-        else if ( line.startsWith( COMPILATION_PREFIX ) )
-        {
-            return null;
-        }*/
-        else if ( line.indexOf( MAGIC_LINE_MARKER ) != -1 )
-        {
-            int i = line.indexOf( MAGIC_LINE_MARKER );
-
-            int j = line.indexOf( ' ', i );
-
-            file = line.substring( 0, i + 3 );
-
-            String linecol = line.substring( i + MAGIC_LINE_MARKER.length(), j - 2 );
-
-            String linenum = null;
-            String colnum = null;
-
-            if ( linecol.indexOf( "," ) > -1 && linecol.split( "," ).length == 2 )
-            {
-                linenum = linecol.split( "," )[0];
-                colnum = linecol.split( "," )[1];
-            }
-            else if ( linecol.split( "," ).length == 1 )
-            {
-                linenum = linecol.split( "," )[0];
-                colnum = "-1";
-            }
-            else
-            {
-                linenum = linecol.trim();
-                colnum = "-1";
-            }
-
-            startline = StringUtils.isEmpty( linenum ) ? -1 : Integer.parseInt( linenum );
-
-            startcolumn = StringUtils.isEmpty( colnum ) ? -1 : Integer.parseInt( colnum );
-
-            endline = startline;
-
-            endcolumn = startcolumn;
-
-            message = line.substring( j + 1 + ERROR_PREFIX.length() );
-
-            error = line.indexOf( "): error" ) != -1;
-        }
-        else
-        {
-            System.err.println( "Unknown output: " + line );
-
-            return null;
-        }
-
-        return new CompilerMessage( file, error ? Kind.ERROR : Kind.NOTE, startline, startcolumn, endline, endcolumn, message );
     }
 
 }

--- a/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/DefaultJ2ObjCCompilerParser.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/DefaultJ2ObjCCompilerParser.java
@@ -11,7 +11,7 @@ import org.codehaus.plexus.util.StringUtils;
 public class DefaultJ2ObjCCompilerParser
 {
 
-    private static String ERROR_PREFIX = "error ";
+    private static String ERROR_PREFIX = "error: ";
 
     private static String CONVERT_PREFIX = "translating ";
     
@@ -67,7 +67,7 @@ Unknown output: Translated 2 methods as functions
     {
 
         String file = null;
-        boolean error = true;
+        boolean error = false;
         int startline = -1;
         int startcolumn = -1;
         int endline = -1;
@@ -77,6 +77,7 @@ Unknown output: Translated 2 methods as functions
         if ( line.startsWith( ERROR_PREFIX ) )
         {
             message = line.substring( ERROR_PREFIX.length() );
+            error = true;
         }
         else if ( line.startsWith( CONVERT_PREFIX ) )
         {

--- a/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompiler.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompiler.java
@@ -18,18 +18,14 @@ package org.codehaus.plexus.compiler.j2objc;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.codehaus.plexus.compiler.AbstractCompiler;
 import org.codehaus.plexus.compiler.CompilerConfiguration;
@@ -38,8 +34,6 @@ import org.codehaus.plexus.compiler.CompilerMessage;
 import org.codehaus.plexus.compiler.CompilerMessage.Kind;
 import org.codehaus.plexus.compiler.CompilerOutputStyle;
 import org.codehaus.plexus.compiler.CompilerResult;
-import org.codehaus.plexus.util.DirectoryScanner;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
@@ -48,466 +42,269 @@ import org.codehaus.plexus.util.cli.StreamConsumer;
 import org.codehaus.plexus.util.cli.WriterStreamConsumer;
 
 /**
- * A plexus compiler which use J2ObjC .
- * It is derived from the CSharpCompiler to compile with J2ObjC.
+ * A plexus compiler which use J2ObjC . It is derived from the CSharpCompiler to
+ * compile with J2ObjC.
  * 
- * @author <a href="mailto:ludovic.maitre@effervens.com">Ludovic Ma&icirc;tre</a>
+ * @author <a href="mailto:ludovic.maitre@effervens.com">Ludovic
+ *         Ma&icirc;tre</a>
  * @see CSharpCompiler
  * @plexus.component role="org.codehaus.plexus.compiler.Compiler"
- * role-hint="j2objc"
+ *                   role-hint="j2objc"
  */
-public class J2ObjCCompiler
-    extends AbstractCompiler
-{
-    private static final String ARGUMENTS_FILE_NAME = "j2objc-arguments";
-
-    private static final String X_BOOTCLASSPATH = "Xbootclasspath";
-
-    /**
-     *    -J<flag>                     Pass Java <flag>, such as -Xmx1G, to the system runtime.
-     */
-    private static final String J_FLAG = "J";
-    
-    /**
-     * --batch-translate-max=<n>    The maximum number of source files that are translated.
-                                  together. Batching speeds up translation, but
-                                  requires more memory.
-     */
-    private static final String BATCH_SIZE = "batch-translate-max";
-
-    /**
-    -pluginpath <path>           Specify where to find plugin class files.
-    -pluginoptions <options>     Comma separated key=value pairs passed to all plugins.
-    -t            Print time spent in translation steps.
-    -Xbootclasspath:<path>       Boot path used by translation (not the tool itself).
-    -Xno-jsni-warnings           Warn if JSNI (GWT) native code delimiters are used
-                                   instead of OCNI delimiters.
-    -sourcepath <path>           Specify where to find input source files.
-    -classpath <path>            Specify where to find user class files.
-    -d <directory>               Specify where to place generated Objective-C files.
-    -encoding <encoding>         Specify character encoding used by source files.
-    -g                           Generate Java source debugging support.
-    -q			                  Do not print status messages.
-    -v          	      Output messages about what the translator is doing.
-    -Werror                      Make all warnings into errors.
-    -h                   Print this message.
-    -use-arc                     Generate Objective-C code to support Automatic
-                                   Reference Counting (ARC).
-    -use-reference-counting      Generate Objective-C code to support iOS manual
-                                   reference counting (default).
-    -x <language>                Specify what language to output.  Possible values
-                                   are objective-c (default) and objective-c++.                              
-     */    
-    private static final List<String> ONE_DASH_ARGS = Arrays.asList( new String[] {
-    		"-pluginpath",
-    		"-pluginoptions",
-    		"-t",
-    		"-Xno-jsni-warnings",
-    		"-sourcepath",
-    		"-classpath",
-    		"-d",
-    		"-encoding",
-    		"-g",
-    		"-q",
-    		"-v",
-    		"-Werror",
-    		"-h",
-    		"-use-arc",
-    		"-use-reference-counting",
-    		"-x"    		
-    });
-
-    /**
-   --build-closure              Translate dependent classes if out-of-date.
-   --dead-code-report <file>    Specify a ProGuard usage report for dead code elimination.
-   --doc-comments               Translate Javadoc comments into Xcode-compatible comments.
-   --no-extract-unsequenced     Don't rewrite expressions that would produce unsequenced
-                                  modification errors.
-   --generate-deprecated        Generate deprecated attributes for deprecated methods,
-                                  classes and interfaces.
-   --mapping <file>             Add a method mapping file.
-   --no-class-methods           Don't emit class methods for static Java methods.
-                                  (static methods are always converted to functions)
-   --no-final-methods-functions Disable generating functions for final methods.
-   --no-hide-private-members    Includes private fields and methods in header file.
-   --no-package-directories     Generate output files to specified directory, without
-                                  creating package sub-directories.
-   --prefix <package=prefix>    Substitute a specified prefix for a package name.
-   --prefixes <file>            Specify a properties file with prefix definitions.
-   --preserve-full-paths        Generates output files with the same relative paths as 
-                                  the input files.
-   --strip-gwt-incompatible     Removes methods that are marked with a GwtIncompatible
-                                  annotation, unless its value is known to be compatible.
-   --strip-reflection           Do not generate metadata needed for Java reflection.
-   --segmented-headers          Generates headers with guards around each declared type.
-                                  Useful for breaking import cycles.
-   --timing-info            Print time spent in translation steps.
-   --quiet                  Do not print status messages.
-   --verbose                Output messages about what the translator is doing.
-   --help                   Print this message.
-   */    
-    private static final List<String> TWO_DASH_ARGS = Arrays.asList( new String[] {
-    	"--build-closure",
-    	"--dead-code-report",
-    	"--doc-comments",
-    	"--no-extract-unsequenced",
-    	"--generate-deprecated",
-    	"--mapping",
-    	"--no-class-methods",
-    	"--no-final-methods-functions",
-    	"--no-hide-private-members",
-    	"--no-package-directories",
-    	"--prefix",
-    	"--prefixes",
-    	"--preserve-full-paths",
-    	"--strip-gwt-incompatible",
-    	"--strip-reflection",
-    	"--segmented-headers",
-    	"--timing-info",
-    	"--quiet",
-    	"--verbose",
-    	"--help"    	
-    } );
-    
-    // ----------------------------------------------------------------------
-    //
-    // ----------------------------------------------------------------------
-
-    public J2ObjCCompiler()
-    {
-        super( CompilerOutputStyle.ONE_OUTPUT_FILE_PER_INPUT_FILE, ".java", null, null );
-    }
-
-    // ----------------------------------------------------------------------
-    // Compiler Implementation
-    // ----------------------------------------------------------------------
-
-    public boolean canUpdateTarget( CompilerConfiguration configuration )
-        throws CompilerException
-    {
-        return false;
-    }
-
-    public CompilerResult performCompile( CompilerConfiguration config )
-        throws CompilerException
-    {
-        File destinationDir = new File( config.getOutputLocation() );
-        if ( !destinationDir.exists() )
-        {
-            destinationDir.mkdirs();
-        }
-
-        config.setSourceFiles( null );
-
-        String[] sourceFiles = J2ObjCCompiler.getSourceFiles( config );
-
-        if ( sourceFiles.length == 0 )
-        {
-            return new CompilerResult().success( true );
-        }
-
-        System.out.println( "Compiling " + sourceFiles.length + " " + "source file" +
-                                ( sourceFiles.length == 1 ? "" : "s" ) + " to " + destinationDir.getAbsolutePath() );
-
-        String[] args = buildCompilerArguments( config, sourceFiles );
-
-        List<CompilerMessage> messages;
-
-        if ( config.isFork() )
-        {
-            messages =
-                compileOutOfProcess( config.getWorkingDirectory(), config.getBuildDirectory(), findExecutable( config ),
-                                     args );
-        }
-        else
-        {
-            throw new CompilerException( "This compiler doesn't support in-process compilation." );
-        }
-
-        return new CompilerResult().compilerMessages( messages );
-    }
-
-    public String[] createCommandLine( CompilerConfiguration config )
-        throws CompilerException
-    {    	
-        return buildCompilerArguments( config, J2ObjCCompiler.getSourceFiles( config ) );
-    }
-
-    // ----------------------------------------------------------------------
-    //
-    // ----------------------------------------------------------------------
-
-    private String findExecutable( CompilerConfiguration config )
-    {
-        String executable = config.getExecutable();
-
-        if ( !StringUtils.isEmpty( executable ) )
-        {
-            return executable;
-        }
-
-        return "j2objc";
-    }
-
-    private String[] buildCompilerArguments( CompilerConfiguration config, String[] sourceFiles )
-        throws CompilerException
-    {
-    	/*
-    	j2objc --help
-    	Usage: j2objc <options> <source files>
-    	*/    	
-        List<String> args = new ArrayList<String>();
-        Map<String, String> compilerArguments = config.getCustomCompilerArgumentsAsMap();
-
-        // Verbose
-        if ( config.isVerbose() )
-        {
-            args.add( "-v" );
-        }
-
-        // Destination/output directory
-        args.add( "-d");
-        args.add(config.getOutputLocation());
-        
-        // config.isShowWarnings()
-        // config.getSourceVersion()
-        // config.getTargetVersion()
-        // config.getSourceEncoding()
-
-        // ----------------------------------------------------------------------
-        //
-        // ----------------------------------------------------------------------
-
-        if ( !config.getClasspathEntries().isEmpty() ) {
-            List<String> classpath = new ArrayList<String>();
-            for ( String element : config.getClasspathEntries() )
-            {
-                File f = new File( element );
-                classpath.add(f.getAbsolutePath());
-                
-                classpath.add( element );
-            }
-            args.add("-classpath");
-            args.add(StringUtils.join(classpath.toArray(), File.pathSeparator));
-        }
-
-        for ( String k : compilerArguments.keySet() ) {
-        	//System.out.println( k + "=" + compilerArguments.get( k ) );
-        	String v = compilerArguments.get(k);
-        	if ( J_FLAG.equals(k)) {
-        		args.add(J_FLAG+v);
-        	} else if ( X_BOOTCLASSPATH.equals(k)) {
-        		args.add(X_BOOTCLASSPATH+":" + v);
-        	} else if (BATCH_SIZE.equals(k)) {
-        		args.add("-" + BATCH_SIZE +"=" + v);
-        	} else {
-        		if ( TWO_DASH_ARGS.contains( k ) ) {
-                	args.add("-" + k);        			
-        		} else if (ONE_DASH_ARGS.contains(k)) {
-        			args.add(k);
-        		} else {
-        			throw new IllegalArgumentException("The argument " + k + " isnt't a flag recognized by J2ObjC.");
-        		}
-            	if ( v != null ) {
-            		args.add(v);
-            	}        		
-        	}
-        }
-
-        // ----------------------------------------------------------------------
-        // add source files
-        // ----------------------------------------------------------------------
-        //List<String> sources = new ArrayList<String>();
-        for ( String sourceFile : sourceFiles )
-        {
-        	//sources.add(sourceFile)
-            args.add( sourceFile );
-        }
-               
-        return args.toArray( new String[args.size()] );
-    }
-
-    private List<CompilerMessage> compileOutOfProcess( File workingDirectory, File target, String executable,
-                                                       String[] args )
-        throws CompilerException
-    {
-        // ----------------------------------------------------------------------
-        // Build the @arguments file
-        // ----------------------------------------------------------------------
-
-        File file;
-
-        PrintWriter output = null;
-
-        try
-        {
-            file = new File( target, ARGUMENTS_FILE_NAME );
-
-            output = new PrintWriter( new FileWriter( file ) );
-
-            for ( String arg : args )
-            {
-                output.println( arg );
-            }
-        }
-        catch ( IOException e )
-        {
-            throw new CompilerException( "Error writing arguments file.", e );
-        }
-        finally
-        {
-            IOUtil.close( output );
-        }
-
-        // ----------------------------------------------------------------------
-        // Execute!
-        // ----------------------------------------------------------------------
-
-        Commandline cli = new Commandline();
-
-        cli.setWorkingDirectory( workingDirectory.getAbsolutePath() );
-
-        cli.setExecutable( executable );
-
-        cli.addArguments(args);
-
-        Writer stringWriter = new StringWriter();
-
-        StreamConsumer out = new WriterStreamConsumer( stringWriter );
-
-        StreamConsumer err = new WriterStreamConsumer( stringWriter );
-
-        int returnCode;
-
-        List<CompilerMessage> messages;
-
-        try
-        {
-            returnCode = CommandLineUtils.executeCommandLine( cli, out, err );
-
-            messages = parseCompilerOutput( new BufferedReader( new StringReader( stringWriter.toString() ) ) );
-        }
-        catch ( CommandLineException e )
-        {
-            throw new CompilerException( "Error while executing the external compiler.", e );
-        }
-        catch ( IOException e )
-        {
-            throw new CompilerException( "Error while executing the external compiler.", e );
-        }
-
-        if ( returnCode != 0 && messages.isEmpty() )
-        {
-            // TODO: exception?
-            messages.add( new CompilerMessage(
-                "Failure executing the compiler, but could not parse the error:" + EOL + stringWriter.toString(),
-                Kind.ERROR ) );
-        }
-
-        return messages;
-    }
-
-    public static List<CompilerMessage> parseCompilerOutput( BufferedReader bufferedReader )
-        throws IOException
-    {
-        List<CompilerMessage> messages = new ArrayList<CompilerMessage>();
-
-        String line = bufferedReader.readLine();
-
-        while ( line != null )
-        {
-            CompilerMessage compilerError = DefaultJ2ObjCCompilerParser.parseLine( line );
-
-            if ( compilerError != null )
-            {
-                messages.add( compilerError );
-            }
-
-            line = bufferedReader.readLine();
-        }
-
-        return messages;
-    }
-
-    // added for debug purposes.... 
-    protected static String[] getSourceFiles( CompilerConfiguration config )
-    {
-        Set<String> sources = new HashSet<String>();
-
-        Set<File> sourceFiles = config.getSourceFiles();
-
-        if ( sourceFiles != null && !sourceFiles.isEmpty() )
-        {
-            for ( File sourceFile : sourceFiles )
-            {
-                sources.add( sourceFile.getAbsolutePath() );
-            }
-        }
-        else
-        {
-            for ( String sourceLocation : config.getSourceLocations() )
-            {
-                // annotations directory does not always exist and the below scanner fails on non existing directories
-                File potentialSourceDirectory = new File( sourceLocation );
-                if ( potentialSourceDirectory.exists() ) {
-                	sources.addAll( getSourceFilesForSourceRoot( config, sourceLocation ) );
-                }
-            }
-        }
-
-        String[] result;
-
-        if ( sources.isEmpty() )
-        {
-            result = new String[0];
-        }
-        else
-        {
-            result = (String[]) sources.toArray( new String[sources.size()] );
-        }
-
-        return result;
-    }
-
-    protected static Set<String> getSourceFilesForSourceRoot( CompilerConfiguration config, String sourceLocation )
-    {
-        DirectoryScanner scanner = new DirectoryScanner();
-        
-        scanner.setBasedir( sourceLocation );
-
-        Set<String> includes = config.getIncludes();
-
-        if ( includes != null && !includes.isEmpty() )
-        {
-            String[] inclStrs = includes.toArray( new String[includes.size()] );
-            scanner.setIncludes( inclStrs );
-        }
-        else
-        {
-            scanner.setIncludes( new String[]{ "**/*.java" } );
-        }
-
-        Set<String> excludes = config.getExcludes();
-
-        if ( excludes != null && !excludes.isEmpty() )
-        {
-            String[] exclStrs = excludes.toArray( new String[excludes.size()] );
-            scanner.setIncludes( exclStrs );
-        }
-
-        scanner.scan();
-
-        String[] sourceDirectorySources = scanner.getIncludedFiles();
-
-        Set<String> sources = new HashSet<String>();
-
-        for ( String source : sourceDirectorySources )
-        {
-            File f = new File( sourceLocation, source );
-
-            sources.add( f.getPath() );
-        }
-
-        return sources;
-    }
+public class J2ObjCCompiler extends AbstractCompiler {
+
+	private static final String X_BOOTCLASSPATH = "Xbootclasspath";
+
+	/**
+	 * -J<flag> Pass Java <flag>, such as -Xmx1G, to the system runtime.
+	 */
+	private static final String J_FLAG = "J";
+
+	/**
+	 * --batch-translate-max=<n> The maximum number of source files that are
+	 * translated. together. Batching speeds up translation, but requires more
+	 * memory.
+	 */
+	private static final String BATCH_SIZE = "batch-translate-max";
+
+	/**
+	 * Put the arguments of j2objc who takes one dash inside an array, in order
+	 * the check the command line.
+	 */
+	private static final List<String> ONE_DASH_ARGS = Arrays
+			.asList(new String[] { "-pluginpath", "-pluginoptions", "-t",
+					"-Xno-jsni-warnings", "-sourcepath", "-classpath", "-d",
+					"-encoding", "-g", "-q", "-v", "-Werror", "-h", "-use-arc",
+					"-use-reference-counting", "-x" });
+
+	/**
+	 * Put the command line arguments with 2 dashes inside an array, in order
+	 * the check the command line and build it.
+	 */
+	private static final List<String> TWO_DASH_ARGS = Arrays
+			.asList(new String[] { "--build-closure", "--dead-code-report",
+					"--doc-comments", "--no-extract-unsequenced",
+					"--generate-deprecated", "--mapping", "--no-class-methods",
+					"--no-final-methods-functions",
+					"--no-hide-private-members", "--no-package-directories",
+					"--prefix", "--prefixes", "--preserve-full-paths",
+					"--strip-gwt-incompatible", "--strip-reflection",
+					"--segmented-headers", "--timing-info", "--quiet",
+					"--verbose", "--help" });
+
+	public J2ObjCCompiler() {
+		super(CompilerOutputStyle.ONE_OUTPUT_FILE_PER_INPUT_FILE, ".java",
+				null, null);
+	}
+
+	// ----------------------------------------------------------------------
+	// Compiler Implementation
+	// ----------------------------------------------------------------------
+
+	public boolean canUpdateTarget(CompilerConfiguration configuration)
+			throws CompilerException {
+		return false;
+	}
+
+	public CompilerResult performCompile(CompilerConfiguration config)
+			throws CompilerException {
+		File destinationDir = new File(config.getOutputLocation());
+		if (!destinationDir.exists()) {
+			destinationDir.mkdirs();
+		}
+
+		config.setSourceFiles(null);
+
+		String[] sourceFiles = J2ObjCCompiler.getSourceFiles(config);
+
+		if (sourceFiles.length == 0) {
+			return new CompilerResult().success(true);
+		}
+
+		System.out.println("Compiling " + sourceFiles.length + " "
+				+ "source file" + (sourceFiles.length == 1 ? "" : "s") + " to "
+				+ destinationDir.getAbsolutePath());
+
+		String[] args = buildCompilerArguments(config, sourceFiles);
+
+		List<CompilerMessage> messages;
+
+		if (config.isFork()) {
+			messages = compileOutOfProcess(config.getWorkingDirectory(),
+					config.getBuildDirectory(), findExecutable(config), args);
+		} else {
+			throw new CompilerException(
+					"This compiler doesn't support in-process compilation.");
+		}
+
+		return new CompilerResult().compilerMessages(messages);
+	}
+
+	public String[] createCommandLine(CompilerConfiguration config)
+			throws CompilerException {
+		return buildCompilerArguments(config,
+				J2ObjCCompiler.getSourceFiles(config));
+	}
+
+	/**
+	 * Find the executable given in the configuration or use j2objc from the
+	 * PATH.
+	 * 
+	 * @param config
+	 * @return the List<String> of args
+	 */
+	private String findExecutable(CompilerConfiguration config) {
+		String executable = config.getExecutable();
+
+		if (!StringUtils.isEmpty(executable)) {
+			return executable;
+		}
+
+		return "j2objc";
+	}
+
+	/**
+	 * Build the compiler arguments : 
+	 * <li>the output location is used for -d of j2objc) 
+	 * <li>the classpath entries are added to -classpath 
+	 * <li>the sourcefiles are listed at the end of the command line 
+	 * <li>the configuration can contain any of the arguments
+	 * 
+	 * @param config
+	 * @param sourceFiles
+	 * @return The List<String> to give to the command line tool
+	 * @throws CompilerException
+	 */
+	private String[] buildCompilerArguments(CompilerConfiguration config,
+			String[] sourceFiles) throws CompilerException {
+		/*
+		 * j2objc --help Usage: j2objc <options> <source files>
+		 */
+		List<String> args = new ArrayList<String>();
+		Map<String, String> compilerArguments = config
+				.getCustomCompilerArgumentsAsMap();
+
+		// Verbose
+		if (config.isVerbose()) {
+			args.add("-v");
+		}
+
+		// Destination/output directory
+		args.add("-d");
+		args.add(config.getOutputLocation());
+
+		if (!config.getClasspathEntries().isEmpty()) {
+			List<String> classpath = new ArrayList<String>();
+			for (String element : config.getClasspathEntries()) {
+				File f = new File(element);
+				classpath.add(f.getAbsolutePath());
+
+				classpath.add(element);
+			}
+			args.add("-classpath");
+			args.add(StringUtils.join(classpath.toArray(), File.pathSeparator));
+		}
+
+		if (config.isVerbose()) {
+			System.out.println("Args: ");
+		}
+
+		for (String k : compilerArguments.keySet()) {
+			if (config.isVerbose()) {
+				System.out.println(k + "=" + compilerArguments.get(k));
+			}
+			String v = compilerArguments.get(k);
+			if (J_FLAG.equals(k)) {
+				args.add(J_FLAG + v);
+			} else if (X_BOOTCLASSPATH.equals(k)) {
+				args.add(X_BOOTCLASSPATH + ":" + v);
+			} else if (BATCH_SIZE.equals(k)) {
+				args.add("-" + BATCH_SIZE + "=" + v);
+			} else {
+				if (TWO_DASH_ARGS.contains(k)) {
+					args.add("-" + k);
+				} else if (ONE_DASH_ARGS.contains(k)) {
+					args.add(k);
+				} else {
+					throw new IllegalArgumentException("The argument " + k
+							+ " isnt't a flag recognized by J2ObjC.");
+				}
+				if (v != null) {
+					args.add(v);
+				}
+			}
+		}
+
+		for (String sourceFile : sourceFiles) {
+			args.add(sourceFile);
+		}
+
+		return args.toArray(new String[args.size()]);
+	}
+
+	private List<CompilerMessage> compileOutOfProcess(File workingDirectory,
+			File target, String executable, String[] args)
+			throws CompilerException {
+
+		Commandline cli = new Commandline();
+
+		cli.setWorkingDirectory(workingDirectory.getAbsolutePath());
+
+		cli.setExecutable(executable);
+
+		cli.addArguments(args);
+
+		Writer stringWriter = new StringWriter();
+
+		StreamConsumer out = new WriterStreamConsumer(stringWriter);
+
+		StreamConsumer err = new WriterStreamConsumer(stringWriter);
+
+		int returnCode;
+
+		List<CompilerMessage> messages;
+
+		try {
+			returnCode = CommandLineUtils.executeCommandLine(cli, out, err);
+
+			messages = parseCompilerOutput(new BufferedReader(new StringReader(
+					stringWriter.toString())));
+		} catch (CommandLineException e) {
+			throw new CompilerException(
+					"Error while executing the external compiler.", e);
+		} catch (IOException e) {
+			throw new CompilerException(
+					"Error while executing the external compiler.", e);
+		}
+
+		if (returnCode != 0 && messages.isEmpty()) {
+			// TODO: exception?
+			messages.add(new CompilerMessage(
+					"Failure executing the compiler, but could not parse the error:"
+							+ EOL + stringWriter.toString(), Kind.ERROR));
+		}
+
+		return messages;
+	}
+
+	public static List<CompilerMessage> parseCompilerOutput(
+			BufferedReader bufferedReader) throws IOException {
+		List<CompilerMessage> messages = new ArrayList<CompilerMessage>();
+
+		String line = bufferedReader.readLine();
+
+		while (line != null) {
+			CompilerMessage compilerError = DefaultJ2ObjCCompilerParser
+					.parseLine(line);
+
+			if (compilerError != null) {
+				messages.add(compilerError);
+			}
+
+			line = bufferedReader.readLine();
+		}
+
+		return messages;
+	}
+
 }

--- a/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompiler.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompiler.java
@@ -292,7 +292,7 @@ public class J2ObjCCompiler
         }
 
         for ( String k : compilerArguments.keySet() ) {
-        	System.out.println( k + "=" + compilerArguments.get( k ) );
+        	//System.out.println( k + "=" + compilerArguments.get( k ) );
         	String v = compilerArguments.get(k);
         	if ( J_FLAG.equals(k)) {
         		args.add(J_FLAG+v);

--- a/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompiler.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompiler.java
@@ -1,0 +1,644 @@
+package org.codehaus.plexus.compiler.j2objc;
+
+/*
+ * Copyright 2005 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.codehaus.plexus.compiler.AbstractCompiler;
+import org.codehaus.plexus.compiler.CompilerConfiguration;
+import org.codehaus.plexus.compiler.CompilerException;
+import org.codehaus.plexus.compiler.CompilerMessage;
+import org.codehaus.plexus.compiler.CompilerOutputStyle;
+import org.codehaus.plexus.compiler.CompilerResult;
+import org.codehaus.plexus.util.DirectoryScanner;
+import org.codehaus.plexus.util.IOUtil;
+import org.codehaus.plexus.util.Os;
+import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.cli.CommandLineException;
+import org.codehaus.plexus.util.cli.CommandLineUtils;
+import org.codehaus.plexus.util.cli.Commandline;
+import org.codehaus.plexus.util.cli.StreamConsumer;
+import org.codehaus.plexus.util.cli.WriterStreamConsumer;
+
+/**
+ * A loosy derivation of the CSharpCompiler to compile J2ObjC.
+ * 
+ * @author <a href="mailto:ludovic.maitre@effervens.com">Ludovic Ma&icirc;tre</a>
+ * @see CsharpCompiler
+ * @plexus.component role="org.codehaus.plexus.compiler.Compiler"
+ * role-hint="j2objc"
+ */
+public class J2ObjCCompiler
+    extends AbstractCompiler
+{
+    private static final String ARGUMENTS_FILE_NAME = "j2objc-arguments";
+
+    private static final String[] DEFAULT_INCLUDES = { "**/**" };
+
+    private static void err(String s) {
+    	System.err.println(s);
+    }
+    // ----------------------------------------------------------------------
+    //
+    // ----------------------------------------------------------------------
+
+    public J2ObjCCompiler()
+    {
+        super( CompilerOutputStyle.ONE_OUTPUT_FILE_PER_INPUT_FILE, ".java", null, null );
+    }
+
+    // ----------------------------------------------------------------------
+    // Compiler Implementation
+    // ----------------------------------------------------------------------
+
+    public boolean canUpdateTarget( CompilerConfiguration configuration )
+        throws CompilerException
+    {
+        return false;
+    }
+
+    public String getOutputFile( CompilerConfiguration configuration )
+        throws CompilerException
+    {
+        return configuration.getOutputFileName() + "." + getTypeExtension( configuration );
+    }
+
+    public CompilerResult performCompile( CompilerConfiguration config )
+        throws CompilerException
+    {
+        File destinationDir = new File( config.getOutputLocation() );
+        err("Dest:" + destinationDir.getAbsolutePath() );
+        if ( !destinationDir.exists() )
+        {
+            destinationDir.mkdirs();
+        }
+
+        config.setSourceFiles( null );
+
+        String[] sourceFiles = J2ObjCCompiler.getSourceFiles( config );
+
+        if ( sourceFiles.length == 0 )
+        {
+            return new CompilerResult().success( true );
+        }
+
+        System.out.println( "Compiling " + sourceFiles.length + " " + "source file" +
+                                ( sourceFiles.length == 1 ? "" : "s" ) + " to " + destinationDir.getAbsolutePath() );
+
+        String[] args = buildCompilerArguments( config, sourceFiles );
+
+        List<CompilerMessage> messages;
+
+        if ( config.isFork() )
+        {
+            messages =
+                compileOutOfProcess( config.getWorkingDirectory(), config.getBuildDirectory(), findExecutable( config ),
+                                     args );
+        }
+        else
+        {
+            throw new CompilerException( "This compiler doesn't support in-process compilation." );
+        }
+
+        return new CompilerResult().compilerMessages( messages );
+    }
+
+    public String[] createCommandLine( CompilerConfiguration config )
+        throws CompilerException
+    {
+        return buildCompilerArguments( config, J2ObjCCompiler.getSourceFiles( config ) );
+    }
+
+    // ----------------------------------------------------------------------
+    //
+    // ----------------------------------------------------------------------
+
+    private String findExecutable( CompilerConfiguration config )
+    {
+        String executable = config.getExecutable();
+
+        if ( !StringUtils.isEmpty( executable ) )
+        {
+            return executable;
+        }
+
+        return "j2objc";
+    }
+/*
+ j2objc --help
+Usage: j2objc <options> <source files>
+Common options:
+-sourcepath <path>           Specify where to find input source files.
+-classpath <path>            Specify where to find user class files.
+-d <directory>               Specify where to place generated Objective-C files.
+-encoding <encoding>         Specify character encoding used by source files.
+-g                           Generate Java source debugging support.
+-q, --quiet                  Do not print status messages.
+-v, --verbose                Output messages about what the translator is doing.
+-Werror                      Make all warnings into errors.
+-h, --help                   Print this message.
+
+Other options:
+--batch-translate-max=<n>    The maximum number of source files that are translated.
+                               together. Batching speeds up translation, but
+                               requires more memory.
+--build-closure              Translate dependent classes if out-of-date.
+--dead-code-report <file>    Specify a ProGuard usage report for dead code elimination.
+--doc-comments               Translate Javadoc comments into Xcode-compatible comments.
+--no-extract-unsequenced     Don't rewrite expressions that would produce unsequenced
+                               modification errors.
+--generate-deprecated        Generate deprecated attributes for deprecated methods,
+                               classes and interfaces.
+-J<flag>                     Pass Java <flag>, such as -Xmx1G, to the system runtime.
+--mapping <file>             Add a method mapping file.
+--no-class-methods           Don't emit class methods for static Java methods.
+                               (static methods are always converted to functions)
+--no-final-methods-functions Disable generating functions for final methods.
+--no-hide-private-members    Includes private fields and methods in header file.
+--no-package-directories     Generate output files to specified directory, without
+                               creating package sub-directories.
+-pluginpath <path>           Specify where to find plugin class files.
+-pluginoptions <options>     Comma separated key=value pairs passed to all plugins.
+--prefix <package=prefix>    Substitute a specified prefix for a package name.
+--prefixes <file>            Specify a properties file with prefix definitions.
+--preserve-full-paths        Generates output files with the same relative paths as 
+                               the input files.
+--strip-gwt-incompatible     Removes methods that are marked with a GwtIncompatible
+                               annotation, unless its value is known to be compatible.
+--strip-reflection           Do not generate metadata needed for Java reflection.
+--segmented-headers          Generates headers with guards around each declared type.
+                               Useful for breaking import cycles.
+-t, --timing-info            Print time spent in translation steps.
+-Xbootclasspath:<path>       Boot path used by translation (not the tool itself).
+-Xno-jsni-warnings           Warn if JSNI (GWT) native code delimiters are used
+                               instead of OCNI delimiters.
+ */
+
+    private String[] buildCompilerArguments( CompilerConfiguration config, String[] sourceFiles )
+        throws CompilerException
+    {
+        List<String> args = new ArrayList<String>();
+
+        // Verbose
+        if ( config.isDebug() )
+        {
+            args.add( "-v" );
+        }
+
+        // Destination/output directory
+        args.add( "-d");
+        args.add(config.getOutputLocation());
+        
+        // config.isShowWarnings()
+        // config.getSourceVersion()
+        // config.getTargetVersion()
+        // config.getSourceEncoding()
+
+        // ----------------------------------------------------------------------
+        //
+        // ----------------------------------------------------------------------
+
+        for ( String element : config.getClasspathEntries() )
+        {
+            File f = new File( element );
+
+            if ( !f.isFile() )
+            {
+                continue;
+            }
+
+            args.add( element );
+        }
+
+/*
+-use-arc                     Generate Objective-C code to support Automatic
+                               Reference Counting (ARC).
+-use-reference-counting      Generate Objective-C code to support iOS manual
+                               reference counting (default).
+-x <language>                Specify what language to output.  Possible values
+                               are objective-c (default) and objective-c++.
+
+ */
+        Map<String, String> compilerArguments = config.getCustomCompilerArgumentsAsMap();
+        
+        for ( String k : compilerArguments.keySet() ) {
+        	System.out.println( k + "=" + compilerArguments.get( k ) );
+        }
+        if ( compilerArguments.containsKey("-use-arc") ) {
+        	
+        }
+        String mainClass = compilerArguments.get( "-main" );
+
+        if ( !StringUtils.isEmpty( mainClass ) )
+        {
+            args.add( "/main:" + mainClass );
+        }
+
+        // ----------------------------------------------------------------------
+        // Xml Doc output
+        // ----------------------------------------------------------------------
+
+        String doc = compilerArguments.get( "-doc" );
+
+        if ( !StringUtils.isEmpty( doc ) )
+        {
+            args.add( "/doc:" + new File( config.getOutputLocation(),
+                                          config.getOutputFileName() + ".xml" ).getAbsolutePath() );
+        }
+
+        // ----------------------------------------------------------------------
+        // Xml Doc output
+        // ----------------------------------------------------------------------
+
+        String nowarn = compilerArguments.get( "-nowarn" );
+
+        if ( !StringUtils.isEmpty( nowarn ) )
+        {
+            args.add( "/nowarn:" + nowarn );
+        }
+
+        // ----------------------------------------------------------------------
+        // Out - Override output name, this is required for generating the unit test dll
+        // ----------------------------------------------------------------------
+
+        String out = compilerArguments.get( "-out" );
+        /*
+        if ( !StringUtils.isEmpty( out ) )
+        {
+            args.add( "/out:" + new File( config.getOutputLocation(), out ).getAbsolutePath() );
+        }
+        else
+        {
+            args.add( "/out:" + new File( config.getOutputLocation(), getOutputFile( config ) ).getAbsolutePath() );
+        }*/
+
+        // ----------------------------------------------------------------------
+        // Resource File - compile in a resource file into the assembly being created
+        // ----------------------------------------------------------------------
+        String resourcefile = compilerArguments.get( "-resourcefile" );
+
+        if ( !StringUtils.isEmpty( resourcefile ) )
+        {
+            String resourceTarget = (String) compilerArguments.get( "-resourcetarget" );
+            args.add( "/res:" + new File( resourcefile ).getAbsolutePath() + "," + resourceTarget );
+        }
+
+        // ----------------------------------------------------------------------
+        // Target - type of assembly to produce, lib,exe,winexe etc... 
+        // ----------------------------------------------------------------------
+
+        String target = compilerArguments.get( "-target" );
+        /*
+        if ( StringUtils.isEmpty( target ) )
+        {
+            args.add( "/target:library" );
+        }
+        else
+        {
+            args.add( "/target:" + target );
+        }*/
+
+        // ----------------------------------------------------------------------
+        // remove MS logo from output (not applicable for mono)
+        // ----------------------------------------------------------------------
+        String nologo = compilerArguments.get( "-nologo" );
+
+        if ( !StringUtils.isEmpty( nologo ) )
+        {
+            args.add( "/nologo" );
+        }
+
+        // ----------------------------------------------------------------------
+        // add any resource files
+        // ----------------------------------------------------------------------
+        this.addResourceArgs( config, args );
+
+        // ----------------------------------------------------------------------
+        // add source files
+        // ----------------------------------------------------------------------
+        for ( String sourceFile : sourceFiles )
+        {
+            args.add( sourceFile );
+        }
+               
+        return args.toArray( new String[args.size()] );
+    }
+
+    private void addResourceArgs( CompilerConfiguration config, List<String> args )
+    {
+        File filteredResourceDir = this.findResourceDir( config );
+        if ( ( filteredResourceDir != null ) && filteredResourceDir.exists() )
+        {
+            DirectoryScanner scanner = new DirectoryScanner();
+            scanner.setBasedir( filteredResourceDir );
+            scanner.setIncludes( DEFAULT_INCLUDES );
+            scanner.addDefaultExcludes();
+            scanner.scan();
+
+            List<String> includedFiles = Arrays.asList( scanner.getIncludedFiles() );
+            for ( String name : includedFiles )
+            {
+                File filteredResource = new File( filteredResourceDir, name );
+                String assemblyResourceName = this.convertNameToAssemblyResourceName( name );
+                String argLine = "/resource:\"" + filteredResource + "\",\"" + assemblyResourceName + "\"";
+                if ( config.isDebug() )
+                {
+                    System.out.println( "adding resource arg line:" + argLine );
+                }
+                args.add( argLine );
+
+            }
+        }
+    }
+
+    private File findResourceDir( CompilerConfiguration config )
+    {
+        if ( config.isDebug() )
+        {
+            System.out.println( "Looking for resourcesDir" );
+        }
+        Map<String, String> compilerArguments = config.getCustomCompilerArguments();
+        String tempResourcesDirAsString = (String) compilerArguments.get( "-resourceDir" );
+        File filteredResourceDir = null;
+        if ( tempResourcesDirAsString != null )
+        {
+            filteredResourceDir = new File( tempResourcesDirAsString );
+            if ( config.isDebug() )
+            {
+                System.out.println( "Found resourceDir at: " + filteredResourceDir.toString() );
+            }
+        }
+        else
+        {
+            if ( config.isDebug() )
+            {
+                System.out.println( "No resourceDir was available." );
+            }
+        }
+        return filteredResourceDir;
+    }
+
+    private String convertNameToAssemblyResourceName( String name )
+    {
+        return name.replace( File.separatorChar, '.' );
+    }
+
+    @SuppressWarnings( "deprecation" )
+    private List<CompilerMessage> compileOutOfProcess( File workingDirectory, File target, String executable,
+                                                       String[] args )
+        throws CompilerException
+    {
+        // ----------------------------------------------------------------------
+        // Build the @arguments file
+        // ----------------------------------------------------------------------
+
+        File file;
+
+        PrintWriter output = null;
+
+        try
+        {
+            file = new File( target, ARGUMENTS_FILE_NAME );
+
+            output = new PrintWriter( new FileWriter( file ) );
+
+            for ( String arg : args )
+            {
+                output.println( arg );
+            }
+        }
+        catch ( IOException e )
+        {
+            throw new CompilerException( "Error writing arguments file.", e );
+        }
+        finally
+        {
+            IOUtil.close( output );
+        }
+
+        // ----------------------------------------------------------------------
+        // Execute!
+        // ----------------------------------------------------------------------
+
+        Commandline cli = new Commandline();
+
+        cli.setWorkingDirectory( workingDirectory.getAbsolutePath() );
+
+        cli.setExecutable( executable );
+
+        cli.addArguments(args);
+
+        Writer stringWriter = new StringWriter();
+
+        StreamConsumer out = new WriterStreamConsumer( stringWriter );
+
+        StreamConsumer err = new WriterStreamConsumer( stringWriter );
+
+        int returnCode;
+
+        List<CompilerMessage> messages;
+
+        try
+        {
+            returnCode = CommandLineUtils.executeCommandLine( cli, out, err );
+
+            messages = parseCompilerOutput( new BufferedReader( new StringReader( stringWriter.toString() ) ) );
+        }
+        catch ( CommandLineException e )
+        {
+            throw new CompilerException( "Error while executing the external compiler.", e );
+        }
+        catch ( IOException e )
+        {
+            throw new CompilerException( "Error while executing the external compiler.", e );
+        }
+
+        if ( returnCode != 0 && messages.isEmpty() )
+        {
+            // TODO: exception?
+            messages.add( new CompilerMessage(
+                "Failure executing the compiler, but could not parse the error:" + EOL + stringWriter.toString(),
+                true ) );
+        }
+
+        return messages;
+    }
+
+    public static List<CompilerMessage> parseCompilerOutput( BufferedReader bufferedReader )
+        throws IOException
+    {
+        List<CompilerMessage> messages = new ArrayList<CompilerMessage>();
+
+        String line = bufferedReader.readLine();
+
+        while ( line != null )
+        {
+            CompilerMessage compilerError = DefaultJ2ObjCCompilerParser.parseLine( line );
+
+            if ( compilerError != null )
+            {
+                messages.add( compilerError );
+            }
+
+            line = bufferedReader.readLine();
+        }
+
+        return messages;
+    }
+
+    private String getType( Map<String, String> compilerArguments )
+    {
+        String type = compilerArguments.get( "-target" );
+
+        if ( StringUtils.isEmpty( type ) )
+        {
+            return "library";
+        }
+
+        return type;
+    }
+
+    private String getTypeExtension( CompilerConfiguration configuration )
+        throws CompilerException
+    {
+        String type = getType( configuration.getCustomCompilerArguments() );
+
+        if ( "exe".equals( type ) || "winexe".equals( type ) )
+        {
+            return "exe";
+        }
+
+        if ( "library".equals( type ) || "module".equals( type ) )
+        {
+            return "dll";
+        }
+
+        throw new CompilerException( "Unrecognized type '" + type + "'." );
+    }
+
+    // added for debug purposes.... 
+    protected static String[] getSourceFiles( CompilerConfiguration config )
+    {
+        Set<String> sources = new HashSet<String>();
+
+        //Set sourceFiles = null;
+        //was:
+        Set<File> sourceFiles = config.getSourceFiles();
+
+        if ( sourceFiles != null && !sourceFiles.isEmpty() )
+        {
+            for ( File sourceFile : sourceFiles )
+            {
+                sources.add( sourceFile.getAbsolutePath() );
+            }
+        }
+        else
+        {
+            for ( String sourceLocation : config.getSourceLocations() )
+            {
+                sources.addAll( getSourceFilesForSourceRoot( config, sourceLocation ) );
+            }
+        }
+
+        String[] result;
+
+        if ( sources.isEmpty() )
+        {
+            result = new String[0];
+        }
+        else
+        {
+            result = (String[]) sources.toArray( new String[sources.size()] );
+        }
+
+        return result;
+    }
+
+    /**
+     * This method is just here to maintain the public api. This is now handled in the parse
+     * compiler output function.
+     *
+     * @author Chris Stevenson
+     * @deprecated
+     */
+    public static CompilerMessage parseLine( String line )
+    {
+        return DefaultJ2ObjCCompilerParser.parseLine( line );
+    }
+
+    protected static Set<String> getSourceFilesForSourceRoot( CompilerConfiguration config, String sourceLocation )
+    {
+    	if ( new File( sourceLocation ).exists() == false ) {
+        	System.out.println("Source didn't exist:"+sourceLocation);
+        	return new LinkedHashSet<String>();
+    	} else {
+        	System.out.println("Source:"+sourceLocation);    		
+    	}
+        DirectoryScanner scanner = new DirectoryScanner();
+        
+        scanner.setBasedir( sourceLocation );
+
+        Set<String> includes = config.getIncludes();
+
+        if ( includes != null && !includes.isEmpty() )
+        {
+            String[] inclStrs = includes.toArray( new String[includes.size()] );
+            scanner.setIncludes( inclStrs );
+        }
+        else
+        {
+            scanner.setIncludes( new String[]{ "**/*.java" } );
+        }
+
+        Set<String> excludes = config.getExcludes();
+
+        if ( excludes != null && !excludes.isEmpty() )
+        {
+            String[] exclStrs = excludes.toArray( new String[excludes.size()] );
+            scanner.setIncludes( exclStrs );
+        }
+
+        scanner.scan();
+
+        String[] sourceDirectorySources = scanner.getIncludedFiles();
+
+        Set<String> sources = new HashSet<String>();
+
+        for ( String source : sourceDirectorySources )
+        {
+            File f = new File( sourceLocation, source );
+
+            sources.add( f.getPath() );
+        }
+
+        return sources;
+    }
+}

--- a/plexus-compilers/plexus-compiler-j2objc/src/site/site.xml
+++ b/plexus-compilers/plexus-compiler-j2objc/src/site/site.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/DECORATION/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
+  <body>
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+      <item name="JavaDocs" href="apidocs/index.html"/>
+      <item name="Source Xref" href="xref/index.html"/>
+      <!--item name="FAQ" href="faq.html"/-->
+    </menu>
+
+    <menu ref="parent"/>
+    <menu ref="reports"/>
+  </body>
+</project>

--- a/plexus-compilers/plexus-compiler-j2objc/src/test/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/test/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompilerTest.java
@@ -54,7 +54,7 @@ public class J2ObjCCompilerTest
 		cc.setSourceLocations(Arrays.asList(new String[]{
 				"src/test/resources"
 		}));
-		cc.setExecutable("/Users/lmaitre/apps/j2objc/j2objc");
+		//cc.setExecutable("/Users/lmaitre/apps/j2objc/j2objc");
 		cc.setWorkingDirectory(new File("."));
 		cc.setFork(true);
 		cc.setCustomCompilerArgumentsAsMap(customCompilerArguments);

--- a/plexus-compilers/plexus-compiler-j2objc/src/test/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/test/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompilerTest.java
@@ -36,11 +36,19 @@ import java.io.StringReader;
 import java.util.List;
 
 /**
- * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
+ * @author lmaitre
  */
 public class J2ObjCCompilerTest
     extends TestCase
 {
+	public void testParser() throws IOException {
+		
+	}
+	
+	public void testJ2ObjCCompiler() throws IOException {
+		J2ObjCCompiler comp = new J2ObjCCompiler();
+		//comp.
+	}
 	/*
     public void testParser()
         throws IOException

--- a/plexus-compilers/plexus-compiler-j2objc/src/test/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/test/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompilerTest.java
@@ -47,22 +47,20 @@ public class J2ObjCCompilerTest
 	public void testJ2ObjCCompiler() throws IOException {
 		J2ObjCCompiler comp = new J2ObjCCompiler();
 		Map<String,String> customCompilerArguments = new HashMap<String,String>();
-//			<use-arc/>
 		customCompilerArguments.put("-use-arc", null);
 		customCompilerArguments.put("-sourcepath", "src/test/resources");
 		CompilerConfiguration cc = new CompilerConfiguration();
+		cc.setOutputLocation("target/generated/objective-c");
 		cc.setSourceLocations(Arrays.asList(new String[]{
 				"src/test/resources"
 		}));
-		cc.setExecutable("/Users/lmaitre/apps/j2objc/j2objc");
 		cc.setWorkingDirectory(new File("."));
 		cc.setFork(true);
 		cc.setCustomCompilerArgumentsAsMap(customCompilerArguments);
-		cc.setOutputLocation("target");
 		try {
 			comp.performCompile(cc);
-			Assert.assertTrue(new File("target/de/test/App.h").exists());
-			Assert.assertTrue(new File("target/de/test/App.m").exists());
+			Assert.assertTrue(new File("target/generated/objective-c/de/test/App.h").exists());
+			Assert.assertTrue(new File("target/generated/objective-c/de/test/App.m").exists());
 		} catch ( CompilerException ce ) {
 			fail("An exception has occured: " + ce.getMessage());
 		}

--- a/plexus-compilers/plexus-compiler-j2objc/src/test/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/test/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompilerTest.java
@@ -24,209 +24,48 @@ package org.codehaus.plexus.compiler.j2objc;
  * SOFTWARE.
  */
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import junit.framework.Assert;
 import junit.framework.TestCase;
 
-import org.codehaus.plexus.compiler.CompilerMessage;
-import org.codehaus.plexus.compiler.j2objc.J2ObjCCompiler;
-import org.codehaus.plexus.compiler.j2objc.DefaultJ2ObjCCompilerParser;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.List;
+import org.codehaus.plexus.compiler.CompilerConfiguration;
+import org.codehaus.plexus.compiler.CompilerException;
 
 /**
+ * j2objc must be in the PATH
  * @author lmaitre
  */
 public class J2ObjCCompilerTest
     extends TestCase
 {
-	public void testParser() throws IOException {
-		
-	}
 	
 	public void testJ2ObjCCompiler() throws IOException {
 		J2ObjCCompiler comp = new J2ObjCCompiler();
-		//comp.
+		Map<String,String> customCompilerArguments = new HashMap<String,String>();
+//			<use-arc/>
+		customCompilerArguments.put("-use-arc", null);
+		customCompilerArguments.put("-sourcepath", "src/test/resources");
+		CompilerConfiguration cc = new CompilerConfiguration();
+		cc.setSourceLocations(Arrays.asList(new String[]{
+				"src/test/resources"
+		}));
+		cc.setExecutable("/Users/lmaitre/apps/j2objc/j2objc");
+		cc.setWorkingDirectory(new File("."));
+		cc.setFork(true);
+		cc.setCustomCompilerArgumentsAsMap(customCompilerArguments);
+		cc.setOutputLocation("target");
+		try {
+			comp.performCompile(cc);
+			Assert.assertTrue(new File("target/de/test/App.h").exists());
+			Assert.assertTrue(new File("target/de/test/App.m").exists());
+		} catch ( CompilerException ce ) {
+			fail("An exception has occured: " + ce.getMessage());
+		}
 	}
-	/*
-    public void testParser()
-        throws IOException
-    {
-        CompilerMessage error;
 
-        // ----------------------------------------------------------------------
-        // Test a few concrete lines
-        // ----------------------------------------------------------------------
-
-        error = DefaultJ2ObjCCompilerParser.parseLine( "error CS2008: No files to compile were specified" );
-
-        assertNotNull( error );
-
-        assertEquals( "CS2008: No files to compile were specified", error.getMessage() );
-
-        error = DefaultJ2ObjCCompilerParser.parseLine( "Compilation failed: 1 error(s), 0 warnings" );
-
-        assertNull( error );
-
-        error = DefaultJ2ObjCCompilerParser.parseLine( "Compilation succeeded - 2 warning(s)" );
-
-        assertNull( error );
-
-        error = DefaultJ2ObjCCompilerParser.parseLine(
-            "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./TestRunnerThread.cs(29) error CS0246: Cannot find type 'NameValueCollection'" );
-
-        assertNotNull( error );
-
-        assertEquals( 29, error.getStartLine() );
-
-        assertEquals( -1, error.getStartColumn() );
-
-        assertEquals( 29, error.getEndLine() );
-
-        assertEquals( -1, error.getEndColumn() );
-
-        assertEquals( "CS0246: Cannot find type 'NameValueCollection'", error.getMessage() );
-
-        // ----------------------------------------------------------------------
-        //
-        // ----------------------------------------------------------------------
-
-        String input =
-            "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./TestRunnerThread.cs(5) error CS0234: The type or namespace name `Specialized' could not be found in namespace `System.Collections'\n"
-                +
-                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./TestRunnerThread.cs(29) error CS0246: Cannot find type 'NameValueCollection'\n"
-                +
-                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(4) error CS0234: The type or namespace name `Framework' could not be found in namespace `NUnit'\n"
-                +
-                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(123) error CS0246: Cannot find type 'TestFixtureAttribute'\n"
-                +
-                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(129) error CS0246: Cannot find type 'TestAttribute'\n"
-                +
-                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(135) error CS0246: Cannot find type 'IgnoreAttribute'\n"
-                +
-                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(141) error CS0246: Cannot find type 'ExpectedExceptionAttribute'\n"
-                +
-                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./WarningSuite.cs(49) error CS0506: `NUnit.Core.WarningSuite.Add': cannot override inherited member `TestSuite.Add' because it is not virtual, abstract or override\n"
-                +
-                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./WarningSuite.cs(49) error CS0507: `NUnit.Core.WarningSuite.Add': can't change the access modifiers when overriding inherited member `TestSuite.Add'\n"
-                +
-                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./WarningSuite.cs(56) error CS0115: 'NUnit.Core.WarningSuite.CreateNewSuite(System.Type)': no suitable methods found to override\n"
-                +
-                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./TestRunnerThread.cs(5) error CS0234: The type or namespace name `Specialized' could not be found in namespace `System.Collections'\n"
-                +
-                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./TestRunnerThread.cs(5) error CS0246: The namespace `System.Collections.Specialized' can not be found (missing assembly reference?)\n"
-                +
-                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(4) error CS0234: The type or namespace name `Framework' could not be found in namespace `NUnit'\n"
-                +
-                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(4) error CS0246: The namespace `NUnit.Framework' can not be found (missing assembly reference?)\n"
-                +
-                "Compilation failed: 14 error(s), 0 warnings";
-
-        List<CompilerMessage> messages =
-            J2ObjCCompiler.parseCompilerOutput( new BufferedReader( new StringReader( input ) ) );
-
-        assertNotNull( messages );
-
-        assertEquals( 14, messages.size() );
-    }
-
-    public void testParserCscWin()
-        throws Exception
-    {
-
-        String cscWin =
-            "src\\test\\csharp\\Hierarchy\\Logger.cs(77,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
-                +
-                "src\\test\\csharp\\Hierarchy\\Logger.cs(98,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
-                +
-                "src\\test\\csharp\\Hierarchy\\Logger.cs(126,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
-                +
-                "src\\test\\csharp\\Hierarchy\\Logger.cs(151,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
-                +
-                "src\\test\\csharp\\Hierarchy\\Logger.cs(187,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
-                +
-                "src\\test\\csharp\\Hierarchy\\Logger.cs(222,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
-                +
-                "src\\test\\csharp\\Hierarchy\\Logger.cs(255,33): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
-                +
-                "src\\test\\csharp\\Hierarchy\\Logger.cs(270,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
-                +
-                "src\\test\\csharp\\Util\\PropertiesDictionaryTest.cs(56,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
-                +
-                "src\\main\\csharp\\Flow\\Loader.cs(62,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly reference?)\n"
-                +
-                "src\\main\\csharp\\Ctl\\Aspx\\AspxController.cs(18,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly\n"
-                +
-                "src\\main\\csharp\\Transform\\XsltTransform.cs(78,11): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly\n"
-                +
-                "src\\main\\csharp\\View\\DispatchedViewFactory.cs(20,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assemb\n"
-                +
-                "src\\main\\csharp\\Flow\\ViewRegistry.cs(31,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly refere\n"
-                +
-                "src\\main\\csharp\\Flow\\MasterFactory.cs(50,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly refer\n"
-                +
-                "src\\main\\csharp\\Dispatcher.cs(152,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly reference?)\n"
-                +
-                "src\\main\\csharp\\Flow\\MaverickContext.cs(43,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly ref\n"
-                +
-                "src\\main\\csharp\\Transform\\DocumentTransform.cs(38,12): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assem\n"
-                +
-                "src\\main\\csharp\\Flow\\CommandBase.cs(11,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly referen\n"
-                +
-                "src\\main\\csharp\\Shunt\\LanguageShuntFactory.cs(47,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assemb\n"
-                +
-                "src\\main\\csharp\\Shunt\\LanguageShuntFactory.cs(67,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assemb\n"
-                +
-                "src\\main\\csharp\\Util\\PropertyPopulator.cs(19,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly r\n"
-                +
-                "src\\main\\csharp\\Ctl\\ThrowawayForm.cs(30,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly refere\n"
-                +
-                "src\\main\\csharp\\AssemblyInfo.cs(68,12): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly reference?)\n";
-
-        List<CompilerMessage> messagesWinCsc =
-            J2ObjCCompiler.parseCompilerOutput( new BufferedReader( new StringReader( cscWin ) ) );
-
-        assertNotNull( messagesWinCsc );
-
-        assertEquals( 24, messagesWinCsc.size() );
-
-        assertTrue( "Check that the line number is not -1",
-                    ( (CompilerMessage) messagesWinCsc.get( 0 ) ).getStartLine() != -1 );
-        assertTrue( "Check that the column number is not -1",
-                    ( (CompilerMessage) messagesWinCsc.get( 0 ) ).getStartColumn() != -1 );
-
-    }
-
-    public void testParserMonoWin()
-        throws Exception
-    {
-
-        String monoWin =
-            "C:\\Work\\SCM\\SVN\\javaforge\\maven-csharp\\trunk\\maverick-net\\src\\main\\csharp\\Ctl\\ThrowawayForm.cs(30,27): error CS0246: The type or namespace name `log4net' could not be found. Are you missing a using directive or an assembly reference? error CS0234: No such name or typespace log4net\n"
-                +
-                "C:\\Work\\SCM\\SVN\\javaforge\\maven-csharp\\trunk\\maverick-net\\src\\main\\csharp\\Util\\PropertyPopulator.cs(19,27): error CS0246: The type or namespace name `log4net' could not be found. Are you missing a using directive or an assembly reference? error CS0234: No such name or typespace log4net\n"
-                +
-                "C:\\Work\\SCM\\SVN\\javaforge\\maven-csharp\\trunk\\maverick-net\\src\\main\\csharp\\Flow\\ViewRegistry.cs(31,27): error CS0246: The type or namespace name `log4net' could not be found. Are you missing a using directive or an assembly reference? error CS0234: No such name or typespace log4net\n"
-                +
-                "C:\\Work\\SCM\\SVN\\javaforge\\maven-csharp\\trunk\\maverick-net\\src\\main\\csharp\\Shunt\\LanguageShuntFactory.cs(47,27): error CS0246: The type or namespace name `log4net' could not be found. Are you missing a using directive or an assembly reference? error CS0234: No such name or typespace log4net\n"
-                +
-                "C:\\Work\\SCM\\SVN\\javaforge\\maven-csharp\\trunk\\maverick-net\\src\\main\\csharp\\Shunt\\LanguageShuntFactory.cs(67,27): error CS0246: The type or namespace name `log4net' could not be found. Are you missing a using directive or an assembly reference? error CS0234: No such name or typespace log4net\n"
-                +
-                "Compilation failed: 28 error(s), 0 warnings";
-
-        List<CompilerMessage> messagesMonoWin =
-            J2ObjCCompiler.parseCompilerOutput( new BufferedReader( new StringReader( monoWin ) ) );
-
-        assertNotNull( messagesMonoWin );
-
-        assertEquals( 5, messagesMonoWin.size() );
-
-        assertTrue( "Check that the line number is not -1",
-                    ( (CompilerMessage) messagesMonoWin.get( 0 ) ).getStartLine() != -1 );
-        assertTrue( "Check that the column number is not -1",
-                    ( (CompilerMessage) messagesMonoWin.get( 0 ) ).getStartColumn() != -1 );
-
-    }
-*/
 }

--- a/plexus-compilers/plexus-compiler-j2objc/src/test/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/test/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompilerTest.java
@@ -1,0 +1,224 @@
+package org.codehaus.plexus.compiler.j2objc;
+
+/**
+ * The MIT License
+ *
+ * Copyright (c) 2005, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import junit.framework.TestCase;
+
+import org.codehaus.plexus.compiler.CompilerMessage;
+import org.codehaus.plexus.compiler.j2objc.J2ObjCCompiler;
+import org.codehaus.plexus.compiler.j2objc.DefaultJ2ObjCCompilerParser;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
+ */
+public class J2ObjCCompilerTest
+    extends TestCase
+{
+	/*
+    public void testParser()
+        throws IOException
+    {
+        CompilerMessage error;
+
+        // ----------------------------------------------------------------------
+        // Test a few concrete lines
+        // ----------------------------------------------------------------------
+
+        error = DefaultJ2ObjCCompilerParser.parseLine( "error CS2008: No files to compile were specified" );
+
+        assertNotNull( error );
+
+        assertEquals( "CS2008: No files to compile were specified", error.getMessage() );
+
+        error = DefaultJ2ObjCCompilerParser.parseLine( "Compilation failed: 1 error(s), 0 warnings" );
+
+        assertNull( error );
+
+        error = DefaultJ2ObjCCompilerParser.parseLine( "Compilation succeeded - 2 warning(s)" );
+
+        assertNull( error );
+
+        error = DefaultJ2ObjCCompilerParser.parseLine(
+            "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./TestRunnerThread.cs(29) error CS0246: Cannot find type 'NameValueCollection'" );
+
+        assertNotNull( error );
+
+        assertEquals( 29, error.getStartLine() );
+
+        assertEquals( -1, error.getStartColumn() );
+
+        assertEquals( 29, error.getEndLine() );
+
+        assertEquals( -1, error.getEndColumn() );
+
+        assertEquals( "CS0246: Cannot find type 'NameValueCollection'", error.getMessage() );
+
+        // ----------------------------------------------------------------------
+        //
+        // ----------------------------------------------------------------------
+
+        String input =
+            "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./TestRunnerThread.cs(5) error CS0234: The type or namespace name `Specialized' could not be found in namespace `System.Collections'\n"
+                +
+                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./TestRunnerThread.cs(29) error CS0246: Cannot find type 'NameValueCollection'\n"
+                +
+                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(4) error CS0234: The type or namespace name `Framework' could not be found in namespace `NUnit'\n"
+                +
+                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(123) error CS0246: Cannot find type 'TestFixtureAttribute'\n"
+                +
+                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(129) error CS0246: Cannot find type 'TestAttribute'\n"
+                +
+                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(135) error CS0246: Cannot find type 'IgnoreAttribute'\n"
+                +
+                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(141) error CS0246: Cannot find type 'ExpectedExceptionAttribute'\n"
+                +
+                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./WarningSuite.cs(49) error CS0506: `NUnit.Core.WarningSuite.Add': cannot override inherited member `TestSuite.Add' because it is not virtual, abstract or override\n"
+                +
+                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./WarningSuite.cs(49) error CS0507: `NUnit.Core.WarningSuite.Add': can't change the access modifiers when overriding inherited member `TestSuite.Add'\n"
+                +
+                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./WarningSuite.cs(56) error CS0115: 'NUnit.Core.WarningSuite.CreateNewSuite(System.Type)': no suitable methods found to override\n"
+                +
+                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./TestRunnerThread.cs(5) error CS0234: The type or namespace name `Specialized' could not be found in namespace `System.Collections'\n"
+                +
+                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./TestRunnerThread.cs(5) error CS0246: The namespace `System.Collections.Specialized' can not be found (missing assembly reference?)\n"
+                +
+                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(4) error CS0234: The type or namespace name `Framework' could not be found in namespace `NUnit'\n"
+                +
+                "/home/trygvis/dev/com.myrealbox/trunk/mcs/nunit20/core/./Reflect.cs(4) error CS0246: The namespace `NUnit.Framework' can not be found (missing assembly reference?)\n"
+                +
+                "Compilation failed: 14 error(s), 0 warnings";
+
+        List<CompilerMessage> messages =
+            J2ObjCCompiler.parseCompilerOutput( new BufferedReader( new StringReader( input ) ) );
+
+        assertNotNull( messages );
+
+        assertEquals( 14, messages.size() );
+    }
+
+    public void testParserCscWin()
+        throws Exception
+    {
+
+        String cscWin =
+            "src\\test\\csharp\\Hierarchy\\Logger.cs(77,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
+                +
+                "src\\test\\csharp\\Hierarchy\\Logger.cs(98,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
+                +
+                "src\\test\\csharp\\Hierarchy\\Logger.cs(126,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
+                +
+                "src\\test\\csharp\\Hierarchy\\Logger.cs(151,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
+                +
+                "src\\test\\csharp\\Hierarchy\\Logger.cs(187,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
+                +
+                "src\\test\\csharp\\Hierarchy\\Logger.cs(222,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
+                +
+                "src\\test\\csharp\\Hierarchy\\Logger.cs(255,33): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
+                +
+                "src\\test\\csharp\\Hierarchy\\Logger.cs(270,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
+                +
+                "src\\test\\csharp\\Util\\PropertiesDictionaryTest.cs(56,4): warning CS0618: 'NUnit.Framework.Assertion' is obsolete: 'Use Assert class instead'\n"
+                +
+                "src\\main\\csharp\\Flow\\Loader.cs(62,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly reference?)\n"
+                +
+                "src\\main\\csharp\\Ctl\\Aspx\\AspxController.cs(18,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly\n"
+                +
+                "src\\main\\csharp\\Transform\\XsltTransform.cs(78,11): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly\n"
+                +
+                "src\\main\\csharp\\View\\DispatchedViewFactory.cs(20,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assemb\n"
+                +
+                "src\\main\\csharp\\Flow\\ViewRegistry.cs(31,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly refere\n"
+                +
+                "src\\main\\csharp\\Flow\\MasterFactory.cs(50,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly refer\n"
+                +
+                "src\\main\\csharp\\Dispatcher.cs(152,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly reference?)\n"
+                +
+                "src\\main\\csharp\\Flow\\MaverickContext.cs(43,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly ref\n"
+                +
+                "src\\main\\csharp\\Transform\\DocumentTransform.cs(38,12): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assem\n"
+                +
+                "src\\main\\csharp\\Flow\\CommandBase.cs(11,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly referen\n"
+                +
+                "src\\main\\csharp\\Shunt\\LanguageShuntFactory.cs(47,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assemb\n"
+                +
+                "src\\main\\csharp\\Shunt\\LanguageShuntFactory.cs(67,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assemb\n"
+                +
+                "src\\main\\csharp\\Util\\PropertyPopulator.cs(19,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly r\n"
+                +
+                "src\\main\\csharp\\Ctl\\ThrowawayForm.cs(30,27): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly refere\n"
+                +
+                "src\\main\\csharp\\AssemblyInfo.cs(68,12): error CS0246: The type or namespace name 'log4net' could not be found (are you missing a using directive or an assembly reference?)\n";
+
+        List<CompilerMessage> messagesWinCsc =
+            J2ObjCCompiler.parseCompilerOutput( new BufferedReader( new StringReader( cscWin ) ) );
+
+        assertNotNull( messagesWinCsc );
+
+        assertEquals( 24, messagesWinCsc.size() );
+
+        assertTrue( "Check that the line number is not -1",
+                    ( (CompilerMessage) messagesWinCsc.get( 0 ) ).getStartLine() != -1 );
+        assertTrue( "Check that the column number is not -1",
+                    ( (CompilerMessage) messagesWinCsc.get( 0 ) ).getStartColumn() != -1 );
+
+    }
+
+    public void testParserMonoWin()
+        throws Exception
+    {
+
+        String monoWin =
+            "C:\\Work\\SCM\\SVN\\javaforge\\maven-csharp\\trunk\\maverick-net\\src\\main\\csharp\\Ctl\\ThrowawayForm.cs(30,27): error CS0246: The type or namespace name `log4net' could not be found. Are you missing a using directive or an assembly reference? error CS0234: No such name or typespace log4net\n"
+                +
+                "C:\\Work\\SCM\\SVN\\javaforge\\maven-csharp\\trunk\\maverick-net\\src\\main\\csharp\\Util\\PropertyPopulator.cs(19,27): error CS0246: The type or namespace name `log4net' could not be found. Are you missing a using directive or an assembly reference? error CS0234: No such name or typespace log4net\n"
+                +
+                "C:\\Work\\SCM\\SVN\\javaforge\\maven-csharp\\trunk\\maverick-net\\src\\main\\csharp\\Flow\\ViewRegistry.cs(31,27): error CS0246: The type or namespace name `log4net' could not be found. Are you missing a using directive or an assembly reference? error CS0234: No such name or typespace log4net\n"
+                +
+                "C:\\Work\\SCM\\SVN\\javaforge\\maven-csharp\\trunk\\maverick-net\\src\\main\\csharp\\Shunt\\LanguageShuntFactory.cs(47,27): error CS0246: The type or namespace name `log4net' could not be found. Are you missing a using directive or an assembly reference? error CS0234: No such name or typespace log4net\n"
+                +
+                "C:\\Work\\SCM\\SVN\\javaforge\\maven-csharp\\trunk\\maverick-net\\src\\main\\csharp\\Shunt\\LanguageShuntFactory.cs(67,27): error CS0246: The type or namespace name `log4net' could not be found. Are you missing a using directive or an assembly reference? error CS0234: No such name or typespace log4net\n"
+                +
+                "Compilation failed: 28 error(s), 0 warnings";
+
+        List<CompilerMessage> messagesMonoWin =
+            J2ObjCCompiler.parseCompilerOutput( new BufferedReader( new StringReader( monoWin ) ) );
+
+        assertNotNull( messagesMonoWin );
+
+        assertEquals( 5, messagesMonoWin.size() );
+
+        assertTrue( "Check that the line number is not -1",
+                    ( (CompilerMessage) messagesMonoWin.get( 0 ) ).getStartLine() != -1 );
+        assertTrue( "Check that the column number is not -1",
+                    ( (CompilerMessage) messagesMonoWin.get( 0 ) ).getStartColumn() != -1 );
+
+    }
+*/
+}

--- a/plexus-compilers/plexus-compiler-j2objc/src/test/resources/de/test/App.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/test/resources/de/test/App.java
@@ -1,0 +1,13 @@
+package de.test;
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7-SNAPSHOT</version>
+    <version>2.7</version>
   </parent>
 
   <artifactId>plexus-compiler-javac-errorprone</artifactId>

--- a/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7</version>
+    <version>2.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-javac-errorprone</artifactId>

--- a/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>plexus-compiler-javac-errorprone</artifactId>

--- a/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6</version>
+    <version>2.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-javac-errorprone</artifactId>

--- a/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5</version>
   </parent>
 
   <artifactId>plexus-compiler-javac-errorprone</artifactId>

--- a/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_core</artifactId>
-      <version>2.0</version>
+      <version>2.0.1</version>
     </dependency>
   </dependencies>
 

--- a/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.5</version>
+    <version>2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-javac-errorprone</artifactId>

--- a/plexus-compilers/plexus-compiler-javac/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7</version>
+    <version>2.8-SNAPSHOT</version>
   </parent>
   
   <artifactId>plexus-compiler-javac</artifactId>

--- a/plexus-compilers/plexus-compiler-javac/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5</version>
   </parent>
   
   <artifactId>plexus-compiler-javac</artifactId>

--- a/plexus-compilers/plexus-compiler-javac/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.5</version>
+    <version>2.6-SNAPSHOT</version>
   </parent>
   
   <artifactId>plexus-compiler-javac</artifactId>

--- a/plexus-compilers/plexus-compiler-javac/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7-SNAPSHOT</version>
+    <version>2.7</version>
   </parent>
   
   <artifactId>plexus-compiler-javac</artifactId>

--- a/plexus-compilers/plexus-compiler-javac/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <version>2.6</version>
   </parent>
   
   <artifactId>plexus-compiler-javac</artifactId>

--- a/plexus-compilers/plexus-compiler-javac/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6</version>
+    <version>2.7-SNAPSHOT</version>
   </parent>
   
   <artifactId>plexus-compiler-javac</artifactId>

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -114,6 +114,7 @@ public class JavacCompiler
     // Compiler Implementation
     // ----------------------------------------------------------------------
 
+    @Override
     public CompilerResult performCompile( CompilerConfiguration config )
         throws CompilerException
     {
@@ -267,6 +268,11 @@ public class JavacCompiler
                     buffer.append( procs[i] );
                 }
                 args.add( buffer.toString() );
+            }
+            if ( config.getProcessorPathEntries() != null && !config.getProcessorPathEntries().isEmpty() ) {
+                args.add( "-processorpath" );
+
+                args.add( getPathString( config.getProcessorPathEntries() ) );
             }
         }
 

--- a/plexus-compilers/plexus-compiler-jikes/pom.xml
+++ b/plexus-compilers/plexus-compiler-jikes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7</version>
+    <version>2.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-jikes</artifactId>

--- a/plexus-compilers/plexus-compiler-jikes/pom.xml
+++ b/plexus-compilers/plexus-compiler-jikes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.5</version>
+    <version>2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-jikes</artifactId>

--- a/plexus-compilers/plexus-compiler-jikes/pom.xml
+++ b/plexus-compilers/plexus-compiler-jikes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5</version>
   </parent>
 
   <artifactId>plexus-compiler-jikes</artifactId>

--- a/plexus-compilers/plexus-compiler-jikes/pom.xml
+++ b/plexus-compilers/plexus-compiler-jikes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.7-SNAPSHOT</version>
+    <version>2.7</version>
   </parent>
 
   <artifactId>plexus-compiler-jikes</artifactId>

--- a/plexus-compilers/plexus-compiler-jikes/pom.xml
+++ b/plexus-compilers/plexus-compiler-jikes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6</version>
+    <version>2.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-jikes</artifactId>

--- a/plexus-compilers/plexus-compiler-jikes/pom.xml
+++ b/plexus-compilers/plexus-compiler-jikes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compilers</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>plexus-compiler-jikes</artifactId>

--- a/plexus-compilers/pom.xml
+++ b/plexus-compilers/pom.xml
@@ -20,6 +20,7 @@
     <module>plexus-compiler-jikes</module>
     <module>plexus-compiler-javac</module>
     <module>plexus-compiler-javac-errorprone</module>
+    <module>plexus-compiler-j2objc</module>
   </modules>
 
   <dependencies>

--- a/plexus-compilers/pom.xml
+++ b/plexus-compilers/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.7</version>
+    <version>2.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compilers</artifactId>

--- a/plexus-compilers/pom.xml
+++ b/plexus-compilers/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.5</version>
+    <version>2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compilers</artifactId>

--- a/plexus-compilers/pom.xml
+++ b/plexus-compilers/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.7-SNAPSHOT</version>
+    <version>2.7</version>
   </parent>
 
   <artifactId>plexus-compilers</artifactId>

--- a/plexus-compilers/pom.xml
+++ b/plexus-compilers/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.6</version>
+    <version>2.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compilers</artifactId>

--- a/plexus-compilers/pom.xml
+++ b/plexus-compilers/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>plexus-compilers</artifactId>

--- a/plexus-compilers/pom.xml
+++ b/plexus-compilers/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-compiler</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5</version>
   </parent>
 
   <artifactId>plexus-compilers</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,10 @@
     <connection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</connection>
     <developerConnection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</developerConnection>
     <url>http://github.com/codehaus-plexus/plexus-compiler</url>
-    <tag>plexus-compiler-2.4</tag>
   </scm>
   <issueManagement>
-    <system>jira</system>
-    <url>http://jira.codehaus.org/browse/PLXCOMP/component/12541</url>
+    <system>github</system>
+    <url>https://github.com/codehaus-plexus/plexus-compiler/issues</url>
   </issueManagement>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>plexus-compiler</artifactId>
-  <version>2.5-SNAPSHOT</version>
+  <version>2.5</version>
   <packaging>pom</packaging>
 
   <name>Plexus Compiler</name>
@@ -27,7 +27,7 @@
     <connection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</connection>
     <developerConnection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</developerConnection>
     <url>http://github.com/codehaus-plexus/plexus-compiler</url>
-    <tag>plexus-compiler-2.4</tag>
+    <tag>plexus-compiler-2.5</tag>
   </scm>
   <issueManagement>
     <system>jira</system>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>plexus-compiler</artifactId>
-  <version>2.6</version>
+  <version>2.7-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Plexus Compiler</name>
@@ -27,7 +27,7 @@
     <connection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</connection>
     <developerConnection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</developerConnection>
     <url>http://github.com/codehaus-plexus/plexus-compiler</url>
-    <tag>plexus-compiler-2.6</tag>
+    <tag>plexus-compiler-2.4</tag>
   </scm>
   <issueManagement>
     <system>jira</system>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-components</artifactId>
-    <version>1.3.1</version>
+    <version>4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler</artifactId>
@@ -24,8 +24,8 @@
   </modules>
   
   <scm>
-    <connection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</connection>
-    <developerConnection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</developerConnection>
+    <connection>${scm.url}</connection>
+    <developerConnection>${scm.url}</developerConnection>
     <url>http://github.com/codehaus-plexus/plexus-compiler/tree/${project.scm.tag}/</url>
     <tag>master</tag>
   </scm>
@@ -33,6 +33,16 @@
     <system>github</system>
     <url>https://github.com/codehaus-plexus/plexus-compiler/issues</url>
   </issueManagement>
+  <distributionManagement>
+    <site>
+      <id>github:gh-pages</id>
+      <url>${scm.url}</url>
+    </site>
+  </distributionManagement>
+
+  <properties>
+    <scm.url>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</scm.url>
+  </properties>
 
   <dependencyManagement>
     <dependencies>
@@ -45,11 +55,6 @@
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-compiler-test</artifactId>
         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>3.0.22</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -72,23 +77,7 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.3</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.18.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.4</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.1</version>
           <configuration>
             <releaseProfiles>plexus-release,tools.jar</releaseProfiles>
           </configuration>
@@ -97,9 +86,15 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <topSiteURL>${scm.url}</topSiteURL>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-component-metadata</artifactId>
-        <version>1.6</version>
         <executions>
           <execution>
             <goals>
@@ -109,26 +104,11 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.6</version>
-      </plugin>
     </plugins>
   </build>
 
   <reporting>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.8.1</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.2</version>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-components</artifactId>
-    <version>4.0-SNAPSHOT</version>
+    <version>4.0</version>
   </parent>
 
   <artifactId>plexus-compiler</artifactId>
@@ -80,6 +80,13 @@
           <artifactId>maven-release-plugin</artifactId>
           <configuration>
             <releaseProfiles>plexus-release,tools.jar</releaseProfiles>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <additionalparam>-Xdoclint:none</additionalparam>
           </configuration>
         </plugin>
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>plexus-compiler</artifactId>
-  <version>2.6-SNAPSHOT</version>
+  <version>2.6</version>
   <packaging>pom</packaging>
 
   <name>Plexus Compiler</name>
@@ -27,7 +27,7 @@
     <connection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</connection>
     <developerConnection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</developerConnection>
     <url>http://github.com/codehaus-plexus/plexus-compiler</url>
-    <tag>plexus-compiler-2.4</tag>
+    <tag>plexus-compiler-2.6</tag>
   </scm>
   <issueManagement>
     <system>jira</system>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
-      <version>4.11</version>
+      <version>4.12</version>
     </dependency>
   </dependencies>
 
@@ -73,12 +73,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
+          <version>3.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.17</version>
+          <version>2.18.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -99,6 +99,7 @@
       <plugin>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-component-metadata</artifactId>
+        <version>1.6</version>
         <executions>
           <execution>
             <goals>
@@ -111,6 +112,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.6</version>
       </plugin>
     </plugins>
   </build>
@@ -120,17 +122,17 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.7</version>
+        <version>2.8.1</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.2</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
+        <version>2.7</version>
       </plugin>
     </plugins>
   </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>plexus-compiler</artifactId>
-  <version>2.7</version>
+  <version>2.8-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Plexus Compiler</name>
@@ -27,7 +27,7 @@
     <connection>${scm.url}</connection>
     <developerConnection>${scm.url}</developerConnection>
     <url>http://github.com/codehaus-plexus/plexus-compiler/tree/${project.scm.tag}/</url>
-    <tag>plexus-compiler-2.7</tag>
+    <tag>master</tag>
   </scm>
   <issueManagement>
     <system>github</system>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>plexus-compiler</artifactId>
-  <version>2.7-SNAPSHOT</version>
+  <version>2.7</version>
   <packaging>pom</packaging>
 
   <name>Plexus Compiler</name>
@@ -27,7 +27,7 @@
     <connection>${scm.url}</connection>
     <developerConnection>${scm.url}</developerConnection>
     <url>http://github.com/codehaus-plexus/plexus-compiler/tree/${project.scm.tag}/</url>
-    <tag>master</tag>
+    <tag>plexus-compiler-2.7</tag>
   </scm>
   <issueManagement>
     <system>github</system>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>plexus-compiler</artifactId>
-  <version>2.5</version>
+  <version>2.6-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Plexus Compiler</name>
@@ -27,7 +27,7 @@
     <connection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</connection>
     <developerConnection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</developerConnection>
     <url>http://github.com/codehaus-plexus/plexus-compiler</url>
-    <tag>plexus-compiler-2.5</tag>
+    <tag>plexus-compiler-2.4</tag>
   </scm>
   <issueManagement>
     <system>jira</system>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>3.0.10</version>
+        <version>3.0.22</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,8 @@
   <scm>
     <connection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</connection>
     <developerConnection>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</developerConnection>
-    <url>http://github.com/codehaus-plexus/plexus-compiler</url>
+    <url>http://github.com/codehaus-plexus/plexus-compiler/tree/${project.scm.tag}/</url>
+    <tag>master</tag>
   </scm>
   <issueManagement>
     <system>github</system>


### PR DESCRIPTION
There seems to be a problem where the eclipse compiler doesn't see classes in packages that have uppercase letters in them. I've personally seen errors when trying to use the compiler when my classes try to import classes under `org.xbill.DNS`. And there are the following stack overflow questions where people ran into the same error, and in both cases the classes reported as not being found are in packages with uppercase letters in them:
- http://stackoverflow.com/questions/17712838 (package: `com.Ostermiller`)
- http://stackoverflow.com/questions/17749375 (package: `org.omg.CORBA`)

This pull request includes two commits. The first adds a test case for importing one class from another: `org.codehaus.foo.Import` imports `org.codehaus.bar.Baz`, and `EclipseCompilerTest` was adjusted to expect the two new class files. All tests pass with this commit.

The second commit just changes `org.codehaus.bar.Baz` to `org.codehaus.BAR.Baz`, and with this commit the test fails with the following errors in the out file:

```
----
/Users/user/projects/plexus-compiler/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Import.java
The import org.codehaus.BAR cannot be resolved
----
----
/Users/user/projects/plexus-compiler/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Import.java
Baz cannot be resolved to a type
----
```
